### PR TITLE
Add page resize by dragging edges in focused mode (closes #29)

### DIFF
--- a/docs/developers/ai-agent-notes.md
+++ b/docs/developers/ai-agent-notes.md
@@ -30,8 +30,8 @@ this **before** doing any work.
 - **Always** create a new git branch off of `main` for any new work
 - **Always** run all commands and reasoning in the foreground
 - **ALways** use the active terminal to run any commands
-- **Never** split commands with `;`, **always** use `&&` or if you can't,
-  split them up.
+- **Never** issue compound commands — no `;`, no `&&`, no `||`. Each
+  terminal invocation must be a single command.
 - **Never** wrap commands in `cmd /c "..."`, **always** run `cmd` on its
   own first if you're not already in cmd.
 - When asked to offer multiple choices, **never** present option picking

--- a/src/renderer/scripts/app.js
+++ b/src/renderer/scripts/app.js
@@ -6,6 +6,7 @@
 /// <reference path="../../types.d.ts" />
 
 import { Editor } from './editor/editor.js';
+import { initPageResizeHandles } from './editor/page-resize.js';
 import { KeyboardHandler } from './handlers/keyboard-handler.js';
 import { MenuHandler } from './handlers/menu-handler.js';
 import { applyColors, applyMargins, applyPageWidth } from './preferences/preferences-modal.js';
@@ -74,6 +75,9 @@ class App {
         // Initialize editor
         this.editor = new Editor(editorContainer);
         await this.editor.initialize();
+
+        // Initialize page resize handles (focused mode only)
+        initPageResizeHandles(editorContainer);
 
         // Initialize toolbar
         this.toolbar = new Toolbar(toolbarContainer, this.editor);

--- a/src/renderer/scripts/editor/page-resize.js
+++ b/src/renderer/scripts/editor/page-resize.js
@@ -1,0 +1,249 @@
+/**
+ * @fileoverview Page resize handles for the focused-mode editor.
+ *
+ * Adds invisible drag handles to the left and right edges of the "paper"
+ * element.  Dragging either handle resizes the page width symmetrically
+ * and persists the new width to settings.
+ *
+ * The handles use `position: fixed` so they are never clipped by the
+ * editor-container's scrollbar or overflow.  A ResizeObserver and scroll
+ * listener keep them aligned with the paper's visual edges.
+ *
+ * The drag uses delta math: on mousedown the initial mouse-X and initial
+ * page width are captured.  During mousemove, the new width is computed
+ * from the initial width plus the delta, so there is never a visual jump
+ * when the drag starts.
+ */
+
+/// <reference path="../../../types.d.ts" />
+
+import { applyPageWidth } from '../preferences/preferences-modal.js';
+
+/** Minimum page width in pixels. */
+export const MIN_WIDTH_PX = 300;
+
+/**
+ * Computes the clamped new page width after a drag delta.
+ *
+ * Pure function — no DOM access — so it can be unit-tested.
+ *
+ * @param {object}          opts
+ * @param {number}          opts.startWidth      - Editor width (px) at mousedown
+ * @param {number}          opts.startX          - Mouse X at mousedown
+ * @param {number}          opts.currentX        - Current mouse X
+ * @param {'left'|'right'}  opts.side            - Which handle is being dragged
+ * @param {number}          opts.maxContainerWidth - Available container width (px)
+ * @returns {number} New page width in pixels, clamped to [MIN_WIDTH_PX, maxContainerWidth - 40]
+ */
+export function computeNewWidth({ startWidth, startX, currentX, side, maxContainerWidth }) {
+    const dx = currentX - startX;
+    const widthDelta = side === 'right' ? dx * 2 : -dx * 2;
+    const maxWidth = maxContainerWidth - 40;
+    return Math.round(Math.max(MIN_WIDTH_PX, Math.min(maxWidth, startWidth + widthDelta)));
+}
+
+/**
+ * Initialises left and right resize handles for the editor page.
+ *
+ * @param {HTMLElement} editor - The `.editor` paper element (`#editor`).
+ */
+export function initPageResizeHandles(editor) {
+    const container = editor.parentElement;
+    if (!container) return;
+
+    const leftHandle = _createHandle('left');
+    const rightHandle = _createHandle('right');
+
+    document.body.appendChild(leftHandle);
+    document.body.appendChild(rightHandle);
+
+    const update = () => _positionHandles(editor, leftHandle, rightHandle);
+
+    update();
+
+    // Re-position whenever the editor or container resizes.
+    const ro = new ResizeObserver(update);
+    ro.observe(editor);
+    ro.observe(container);
+
+    // Re-position on scroll (the editor container is the scroll parent).
+    container.addEventListener('scroll', update, { passive: true });
+
+    _attachDrag(editor, leftHandle, 'left', rightHandle);
+    _attachDrag(editor, rightHandle, 'right', leftHandle);
+}
+
+// ── Private helpers ──────────────────────────────────────────────────
+
+/**
+ * Creates a resize handle element.
+ * @param {'left' | 'right'} side
+ * @returns {HTMLDivElement}
+ */
+function _createHandle(side) {
+    const handle = document.createElement('div');
+    handle.className = `editor-resize-handle editor-resize-handle--${side}`;
+    handle.dataset.side = side;
+    return handle;
+}
+
+/**
+ * Positions both handles at the current left/right edges of the paper
+ * using fixed positioning (viewport coordinates).  Also hides the
+ * handles when the editor is in source mode.
+ *
+ * @param {HTMLElement} editor
+ * @param {HTMLDivElement} leftHandle
+ * @param {HTMLDivElement} rightHandle
+ */
+function _positionHandles(editor, leftHandle, rightHandle) {
+    // Hide in source mode (no fixed-width paper to resize)
+    if (editor.dataset.viewMode === 'source') {
+        leftHandle.style.display = 'none';
+        rightHandle.style.display = 'none';
+        return;
+    }
+    leftHandle.style.display = '';
+    rightHandle.style.display = '';
+
+    const container = editor.parentElement;
+    if (!container) return;
+
+    const editorRect = editor.getBoundingClientRect();
+    const containerRect = container.getBoundingClientRect();
+
+    const handleWidth = 6; // matches CSS width
+    // Vertical extent: clip to the visible portion of the container
+    const top = containerRect.top;
+    const height = containerRect.height;
+
+    leftHandle.style.top = `${top}px`;
+    leftHandle.style.height = `${height}px`;
+    leftHandle.style.left = `${editorRect.left - handleWidth / 2}px`;
+
+    rightHandle.style.top = `${top}px`;
+    rightHandle.style.height = `${height}px`;
+    rightHandle.style.left = `${editorRect.right - handleWidth / 2}px`;
+}
+
+/**
+ * Attaches mousedown → mousemove → mouseup drag behaviour to a handle.
+ *
+ * Uses delta-after-click math: captures the initial mouse-X and initial
+ * page width on mousedown, then computes `initialWidth + delta` during
+ * mousemove so there is zero visual jump at the start of the drag.
+ *
+ * @param {HTMLElement} editor       - The paper element
+ * @param {HTMLDivElement} handle    - The handle being dragged
+ * @param {'left' | 'right'} side   - Which side this handle sits on
+ * @param {HTMLDivElement} otherHandle - The opposite handle (for re-positioning)
+ */
+function _attachDrag(editor, handle, side, otherHandle) {
+    /** @type {number} Mouse X at the moment of mousedown */
+    let startX = 0;
+    /** @type {number} Editor width (px) at the moment of mousedown */
+    let startWidth = 0;
+    /** @type {number} Left-handle starting X (viewport) at mousedown */
+    let startLeftX = 0;
+    /** @type {number} Right-handle starting X (viewport) at mousedown */
+    let startRightX = 0;
+    /** @type {number|null} Pending rAF id */
+    let rafId = null;
+    /** @type {number} Last mouse X seen during this drag */
+    let lastMouseX = 0;
+
+    /** Calls the exported computeNewWidth with current drag state. */
+    const getNewWidth = () => {
+        const container = editor.parentElement;
+        const maxContainerWidth = container ? container.clientWidth : 2040;
+        return computeNewWidth({
+            startWidth,
+            startX,
+            currentX: lastMouseX,
+            side,
+            maxContainerWidth,
+        });
+    };
+
+    /** @param {MouseEvent} e */
+    const onMouseMove = (e) => {
+        e.preventDefault();
+        lastMouseX = e.clientX;
+        if (rafId !== null) return; // coalesce into one frame
+
+        rafId = requestAnimationFrame(() => {
+            rafId = null;
+
+            const newWidth = getNewWidth();
+
+            // Set inline style directly — avoids CSS variable cascade reflow.
+            editor.style.maxWidth = `${newWidth}px`;
+
+            // Position handles directly from the delta — no layout thrash.
+            const halfGrowth = (newWidth - startWidth) / 2;
+            const handleWidth = 6;
+            const newLeftX = startLeftX - halfGrowth - handleWidth / 2;
+            const newRightX = startRightX + halfGrowth - handleWidth / 2;
+
+            handle.style.left = `${side === 'left' ? newLeftX : newRightX}px`;
+            otherHandle.style.left = `${side === 'left' ? newRightX : newLeftX}px`;
+        });
+    };
+
+    const onMouseUp = () => {
+        if (rafId !== null) {
+            cancelAnimationFrame(rafId);
+            rafId = null;
+        }
+        handle.classList.remove('dragging');
+        document.body.style.cursor = '';
+        document.body.style.userSelect = '';
+        document.removeEventListener('mousemove', onMouseMove);
+        document.removeEventListener('mouseup', onMouseUp);
+
+        // Compute final width from the delta (don't rely on rAF having run).
+        const finalWidth = getNewWidth();
+        editor.style.maxWidth = '';
+        applyPageWidth({ useFixed: false, width: finalWidth, unit: 'px' });
+
+        // Snap handles to actual editor rect now that the CSS variable is set.
+        _positionHandles(
+            editor,
+            side === 'left' ? handle : otherHandle,
+            side === 'right' ? handle : otherHandle,
+        );
+
+        _persistPageWidth(finalWidth);
+    };
+
+    handle.addEventListener('mousedown', (e) => {
+        e.preventDefault();
+        startX = e.clientX;
+        startWidth = editor.getBoundingClientRect().width;
+
+        // Capture both handles' current viewport X positions.
+        const editorRect = editor.getBoundingClientRect();
+        startLeftX = editorRect.left;
+        startRightX = editorRect.right;
+
+        handle.classList.add('dragging');
+        document.body.style.cursor = 'ew-resize';
+        document.body.style.userSelect = 'none';
+        document.addEventListener('mousemove', onMouseMove);
+        document.addEventListener('mouseup', onMouseUp);
+    });
+}
+
+/**
+ * Persists the page width to the settings database.
+ * @param {number} widthPx - Width in pixels
+ */
+async function _persistPageWidth(widthPx) {
+    if (!window.electronAPI) return;
+    const pageWidth = { useFixed: false, width: widthPx, unit: 'px' };
+    try {
+        await window.electronAPI.setSetting('pageWidth', pageWidth);
+    } catch {
+        // Non-critical — ignore
+    }
+}

--- a/src/renderer/styles/editor.css
+++ b/src/renderer/styles/editor.css
@@ -39,6 +39,23 @@
     box-shadow: none;
 }
 
+/* ========== Page resize handles ========== */
+
+.editor-resize-handle {
+    position: fixed;
+    width: 6px;
+    cursor: ew-resize;
+    z-index: 10;
+    /* Invisible by default; highlighted on hover/drag */
+}
+
+.editor-resize-handle:hover,
+.editor-resize-handle.dragging {
+    background: var(--color-primary);
+    opacity: 0.3;
+    border-radius: 3px;
+}
+
 /* Line styling */
 .md-line {
     margin-bottom: var(--spacing-sm);

--- a/test/integration/page-resize.spec.js
+++ b/test/integration/page-resize.spec.js
@@ -1,0 +1,145 @@
+/**
+ * @fileoverview Integration tests for page resize handles.
+ *
+ * Verifies that the drag handles appear in focused mode, are hidden in
+ * source mode, and that dragging a handle changes the page width and
+ * persists the new value to settings.
+ *
+ * Drag tests dispatch real DOM MouseEvents via page.evaluate() rather
+ * than using Playwright's mouse abstraction, which does not reliably
+ * trigger the handle's event listeners in Electron.
+ */
+
+import { expect, test } from '@playwright/test';
+import { launchApp, setFocusedView, setSourceView } from './test-utils.js';
+
+/** @type {import('@playwright/test').ElectronApplication} */
+let electronApp;
+
+/** @type {import('@playwright/test').Page} */
+let page;
+
+test.beforeAll(async () => {
+    ({ electronApp, page } = await launchApp());
+});
+
+test.afterAll(async () => {
+    await electronApp.close();
+});
+
+/**
+ * Simulate a drag on a resize handle by dispatching real DOM MouseEvents.
+ * @param {import('@playwright/test').Page} pg
+ * @param {'left'|'right'} side
+ * @param {number} dx - Horizontal pixel distance to drag (positive = rightward)
+ */
+async function simulateDrag(pg, side, dx) {
+    await pg.evaluate(
+        ([s, delta]) => {
+            const d = /** @type {number} */ (delta);
+            const handle = document.querySelector(`.editor-resize-handle--${s}`);
+            if (!handle) throw new Error(`Handle .editor-resize-handle--${s} not found`);
+            const rect = handle.getBoundingClientRect();
+            const startX = rect.left + rect.width / 2;
+            const startY = rect.top + rect.height / 2;
+
+            /** @param {EventTarget} target @param {string} type @param {number} x @param {number} y */
+            const fire = (target, type, x, y) =>
+                target.dispatchEvent(
+                    new MouseEvent(type, { clientX: x, clientY: y, bubbles: true }),
+                );
+
+            fire(handle, 'mousedown', startX, startY);
+            // Several intermediate moves for realism
+            const steps = 5;
+            for (let i = 1; i <= steps; i++) {
+                fire(document, 'mousemove', startX + (d * i) / steps, startY);
+            }
+            fire(document, 'mouseup', startX + d, startY);
+        },
+        [side, dx],
+    );
+    // Let rAF and persist settle
+    await pg.waitForTimeout(200);
+}
+
+test('resize handles are visible in focused mode', async () => {
+    await setFocusedView(page);
+    const left = page.locator('.editor-resize-handle--left');
+    const right = page.locator('.editor-resize-handle--right');
+    await expect(left).toBeAttached();
+    await expect(right).toBeAttached();
+});
+
+test('resize handles are hidden in source mode', async () => {
+    await setSourceView(page);
+    const left = page.locator('.editor-resize-handle--left');
+    const right = page.locator('.editor-resize-handle--right');
+    await expect(left).toBeHidden();
+    await expect(right).toBeHidden();
+    await setFocusedView(page);
+});
+
+test('dragging the right handle increases page width', async () => {
+    await setFocusedView(page);
+
+    // Reset to a known narrow max-width so the drag has room to grow.
+    await page.evaluate(() => {
+        document.documentElement.style.setProperty('--page-max-width', '400px');
+    });
+
+    const initialMaxWidth = await page.evaluate(() =>
+        Number.parseInt(
+            getComputedStyle(document.documentElement).getPropertyValue('--page-max-width'),
+        ),
+    );
+
+    await simulateDrag(page, 'right', 50);
+
+    const newMaxWidth = await page.evaluate(() =>
+        Number.parseInt(
+            getComputedStyle(document.documentElement).getPropertyValue('--page-max-width'),
+        ),
+    );
+    expect(newMaxWidth).toBeGreaterThan(initialMaxWidth);
+});
+
+test('dragging the left handle increases page width', async () => {
+    await setFocusedView(page);
+
+    // Reset to a known narrow max-width so the drag has room to grow.
+    await page.evaluate(() => {
+        document.documentElement.style.setProperty('--page-max-width', '400px');
+    });
+
+    const initialMaxWidth = await page.evaluate(() =>
+        Number.parseInt(
+            getComputedStyle(document.documentElement).getPropertyValue('--page-max-width'),
+        ),
+    );
+
+    await simulateDrag(page, 'left', -50);
+
+    const newMaxWidth = await page.evaluate(() =>
+        Number.parseInt(
+            getComputedStyle(document.documentElement).getPropertyValue('--page-max-width'),
+        ),
+    );
+    expect(newMaxWidth).toBeGreaterThan(initialMaxWidth);
+});
+
+test('page width is persisted to settings after drag', async () => {
+    await setFocusedView(page);
+
+    await simulateDrag(page, 'right', 30);
+
+    const setting = await page.evaluate(async () => {
+        const result = await window.electronAPI?.getSetting('pageWidth');
+        return result?.value;
+    });
+
+    expect(setting).toBeTruthy();
+    expect(setting.useFixed).toBe(false);
+    expect(setting.unit).toBe('px');
+    expect(setting.width).toBeGreaterThan(0);
+});

--- a/test/unit/editor/page-resize.test.js
+++ b/test/unit/editor/page-resize.test.js
@@ -1,0 +1,76 @@
+/**
+ * @fileoverview Unit tests for the page-resize computeNewWidth helper.
+ */
+
+import assert from 'node:assert';
+import { describe, it } from 'node:test';
+import { MIN_WIDTH_PX, computeNewWidth } from '../../../src/renderer/scripts/editor/page-resize.js';
+
+describe('computeNewWidth', () => {
+    const defaults = {
+        startWidth: 600,
+        startX: 400,
+        currentX: 400,
+        side: /** @type {const} */ ('right'),
+        maxContainerWidth: 1200,
+    };
+
+    it('returns startWidth when there is no mouse movement', () => {
+        const result = computeNewWidth(defaults);
+        assert.strictEqual(result, 600);
+    });
+
+    describe('right handle', () => {
+        it('dragging right increases width symmetrically (×2)', () => {
+            const result = computeNewWidth({ ...defaults, currentX: 450 });
+            // dx = 50, widthDelta = 100, new = 700
+            assert.strictEqual(result, 700);
+        });
+
+        it('dragging left decreases width symmetrically (×2)', () => {
+            const result = computeNewWidth({ ...defaults, currentX: 350 });
+            // dx = -50, widthDelta = -100, new = 500
+            assert.strictEqual(result, 500);
+        });
+    });
+
+    describe('left handle', () => {
+        it('dragging left increases width symmetrically (×2)', () => {
+            const result = computeNewWidth({
+                ...defaults,
+                side: 'left',
+                currentX: 350,
+            });
+            // dx = -50, widthDelta = -(-100) = 100, new = 700
+            assert.strictEqual(result, 700);
+        });
+
+        it('dragging right decreases width symmetrically (×2)', () => {
+            const result = computeNewWidth({
+                ...defaults,
+                side: 'left',
+                currentX: 450,
+            });
+            // dx = 50, widthDelta = -(100) = -100, new = 500
+            assert.strictEqual(result, 500);
+        });
+    });
+
+    describe('clamping', () => {
+        it('clamps to MIN_WIDTH_PX when dragged too far inward', () => {
+            const result = computeNewWidth({ ...defaults, currentX: 100 });
+            // dx = -300, widthDelta = -600, new = 0 → clamped to MIN_WIDTH_PX
+            assert.strictEqual(result, MIN_WIDTH_PX);
+        });
+
+        it('clamps to maxContainerWidth - 40 when dragged too far outward', () => {
+            const result = computeNewWidth({ ...defaults, currentX: 1000 });
+            // dx = 600, widthDelta = 1200, new = 1800 → clamped to 1200 - 40 = 1160
+            assert.strictEqual(result, 1160);
+        });
+
+        it('MIN_WIDTH_PX is 300', () => {
+            assert.strictEqual(MIN_WIDTH_PX, 300);
+        });
+    });
+});


### PR DESCRIPTION
Closes #29

## What was wrong

In focused mode, the only way to change the page width was through the preferences modal. There was no way to interactively resize the page by dragging its edges.

## What changed

Added invisible drag handles on the left and right edges of the editor page in focused mode. Dragging either handle resizes the page width symmetrically and persists the new value to settings.

### New files

- `src/renderer/scripts/editor/page-resize.js` — creates two `position: fixed` handles on `document.body`, aligned to the editor's edges via `getBoundingClientRect()`. A `ResizeObserver` and scroll listener keep them positioned correctly.
- `test/integration/page-resize.spec.js` — 5 integration tests covering visibility, drag behavior, and persistence.
- `test/unit/editor/page-resize.test.js` — 8 unit tests for the `computeNewWidth` pure function.

### Modified files

- `src/renderer/scripts/app.js` — wires up `initPageResizeHandles(editor)` on startup.
- `src/renderer/styles/editor.css` — minimal handle styles: `position: fixed`, 6px wide, `ew-resize` cursor, subtle highlight on hover/drag.
- `docs/developers/ai-agent-notes.md` — clarified compound command rule.

## Why this specific approach

- **`position: fixed` on `document.body`** avoids handles being clipped by the editor container's `overflow-y: auto` scrollbar.
- **Delta math** (`startWidth ± dx × 2`) ensures symmetric resize with no visual jump at drag start.
- **Inline `maxWidth` during drag** instead of updating the `--page-max-width` CSS variable avoids a full document reflow cascade on every frame, which caused visible jitter on large documents. The CSS variable is set once on `mouseup`.
- **`requestAnimationFrame` coalescing** collapses multiple `mousemove` events into one paint.
- **`computeNewWidth` extracted as a pure function** (no DOM access) for unit testability.
- Handles are hidden in source mode (no fixed-width paper to resize).