### PR TITLE
Fix cursor jump when typing inline delimiters in focused view

### DIFF
--- a/docs/developers/ai-agent-notes.md
+++ b/docs/developers/ai-agent-notes.md
@@ -51,15 +51,18 @@ this **before** doing any work.
 - **Always** be explicit about remote and branch when pushing:
   `git push origin <branchname>`. Never use bare `git push` or
   `--set-upstream`.
-- after the work has been completed (as agreed to by the user), write a
-  PR comment in markdown that documents what was wrong, how it got changed
-  and why it needed that specific change. Make sure to also note that the
-  PR closes the issue number, if the work was part of addressing an issue.
+- Do not consider the work done until a final full test suite run passes.
+- After the work has been completed (as agreed to by the user), write a
+  PR comment **in raw markdown**, **not styled text**, that documents what
+  was wrong, how it got changed and why it needed that specific change.
+  Make sure to also note that the PR closes the issue number, if the work
+  was part of addressing an issue.
 
 ## Test Runners
 
 | Kind        | Command                    | Framework                  |
 | ----------- | -------------------------- | -------------------------- |
+| Full suite  | `npm test`                 |                            |
 | Full suite  | `npm test`                 |                            |
 | Linting     | `npm run lint`             | Biome and TSC linting      |
 | Unit        | `npm run test:unit`        | Node.js native test runner |

--- a/src/renderer/scripts/editor/renderers/focused-renderer.js
+++ b/src/renderer/scripts/editor/renderers/focused-renderer.js
@@ -728,24 +728,30 @@ export class FocusedRenderer {
                     const code = document.createElement('code');
                     code.textContent = seg.content ?? '';
                     container.appendChild(code);
+                    // Empty text node so the cursor can land after the
+                    // element rather than being trapped inside it.
+                    container.appendChild(document.createTextNode(''));
                     break;
                 }
                 case 'bold': {
                     const strong = document.createElement('strong');
                     this.appendSegments(seg.children ?? [], strong);
                     container.appendChild(strong);
+                    container.appendChild(document.createTextNode(''));
                     break;
                 }
                 case 'italic': {
                     const em = document.createElement('em');
                     this.appendSegments(seg.children ?? [], em);
                     container.appendChild(em);
+                    container.appendChild(document.createTextNode(''));
                     break;
                 }
                 case 'strikethrough': {
                     const del = document.createElement('del');
                     this.appendSegments(seg.children ?? [], del);
                     container.appendChild(del);
+                    container.appendChild(document.createTextNode(''));
                     break;
                 }
                 case 'link': {
@@ -753,6 +759,7 @@ export class FocusedRenderer {
                     a.href = seg.href ?? '';
                     this.appendSegments(seg.children ?? [], a);
                     container.appendChild(a);
+                    container.appendChild(document.createTextNode(''));
                     break;
                 }
                 default: {
@@ -761,6 +768,7 @@ export class FocusedRenderer {
                         const el = document.createElement(seg.tag);
                         this.appendSegments(seg.children ?? [], el);
                         container.appendChild(el);
+                        container.appendChild(document.createTextNode(''));
                     }
                     break;
                 }

--- a/test/integration/cursor-typing-delimiters.spec.js
+++ b/test/integration/cursor-typing-delimiters.spec.js
@@ -1,0 +1,211 @@
+/**
+ * @fileoverview Integration tests for cursor position while typing inline
+ * delimiters in focused view.
+ *
+ * Verifies the fix for GitHub issue #44: typing `*`, `_`, `~~`, or
+ * `<sub>` should leave the cursor immediately after the typed character,
+ * not jump it backwards.
+ */
+
+import { expect, test } from '@playwright/test';
+import { launchApp, loadContent, setFocusedView } from './test-utils.js';
+
+/** @type {import('@playwright/test').ElectronApplication} */
+let electronApp;
+
+/** @type {import('@playwright/test').Page} */
+let page;
+
+test.beforeAll(async () => {
+    ({ electronApp, page } = await launchApp());
+});
+
+test.afterAll(async () => {
+    await electronApp.close();
+});
+
+/**
+ * Types text into a fresh paragraph by loading empty content, clicking
+ * the editor, then pressing each key individually.  Returns the cursor
+ * offset (character position within the line) after all keys have been
+ * typed.
+ *
+ * @param {import('@playwright/test').Page} pg
+ * @param {string} text - The text to type character by character
+ * @returns {Promise<{cursorOffset: number, lineText: string}>}
+ */
+async function typeAndGetCursor(pg, text) {
+    await loadContent(pg, '');
+    await setFocusedView(pg);
+
+    // Click the editor to focus it.
+    const editor = pg.locator('#editor');
+    await editor.click();
+    await pg.waitForTimeout(100);
+
+    // Type each character individually so the editor processes each keystroke.
+    for (const ch of text) {
+        await pg.keyboard.press(ch);
+        await pg.waitForTimeout(50);
+    }
+    await pg.waitForTimeout(100);
+
+    // Read the cursor position and line text content from the DOM.
+    const result = await pg.evaluate(() => {
+        const sel = window.getSelection();
+        if (!sel || sel.rangeCount === 0) return null;
+
+        const range = sel.getRangeAt(0);
+        const node = range.startContainer;
+        const offset = range.startOffset;
+
+        // Walk up to find the .md-line element
+        let el = node instanceof HTMLElement ? node : node.parentElement;
+        while (el && !el.classList?.contains('md-line')) {
+            el = el.parentElement;
+        }
+        if (!el) return null;
+
+        // Compute the character offset from the start of the line's
+        // text content up to the cursor position.
+        const contentEl = el.querySelector('.md-content') ?? el;
+        const walker = document.createTreeWalker(contentEl, NodeFilter.SHOW_TEXT, null);
+        let charOffset = 0;
+        let textNode = walker.nextNode();
+        while (textNode) {
+            if (textNode === node) {
+                charOffset += offset;
+                break;
+            }
+            charOffset += textNode.textContent?.length ?? 0;
+            textNode = walker.nextNode();
+        }
+
+        return {
+            cursorOffset: charOffset,
+            lineText: contentEl.textContent || '',
+        };
+    });
+
+    return result ?? { cursorOffset: -1, lineText: '' };
+}
+
+test('cursor stays after * when typing "this is a *"', async () => {
+    const { cursorOffset, lineText } = await typeAndGetCursor(page, 'this is a *');
+    expect(lineText).toContain('this is a *');
+    expect(cursorOffset).toBe(lineText.length);
+});
+
+test('cursor stays after _ when typing "this is a _"', async () => {
+    const { cursorOffset, lineText } = await typeAndGetCursor(page, 'this is a _');
+    expect(lineText).toContain('this is a _');
+    expect(cursorOffset).toBe(lineText.length);
+});
+
+test('cursor stays after ~~ when typing "this is a ~~"', async () => {
+    const { cursorOffset, lineText } = await typeAndGetCursor(page, 'this is a ~~');
+    expect(lineText).toContain('this is a ~~');
+    expect(cursorOffset).toBe(lineText.length);
+});
+
+test('cursor stays after < when typing "<sub>"', async () => {
+    const { cursorOffset, lineText } = await typeAndGetCursor(page, '<sub>');
+    expect(lineText).toContain('<sub>');
+    expect(cursorOffset).toBe(lineText.length);
+});
+
+test('cursor stays correct when completing bold **text**', async () => {
+    // Type the full sequence: **bold** — cursor should track correctly
+    // through both matched delimiters.
+    const { cursorOffset, lineText } = await typeAndGetCursor(page, '**bold**');
+    // After the closing **, the rendered text is just "bold" and cursor
+    // should be at the end of the visible text.
+    expect(lineText).toBe('bold');
+    expect(cursorOffset).toBe(4);
+});
+
+test('cursor stays correct when completing italic *text*', async () => {
+    const { cursorOffset, lineText } = await typeAndGetCursor(page, '*italic*');
+    expect(lineText).toBe('italic');
+    expect(cursorOffset).toBe(6);
+});
+
+test('typing after closing * produces plain text, not italic', async () => {
+    // Type "this is a *test*" then type " hello"
+    // The " hello" must NOT be inside the <em> — it should be plain text.
+    await loadContent(page, '');
+    await setFocusedView(page);
+    const editor = page.locator('#editor');
+    await editor.click();
+    await page.waitForTimeout(100);
+
+    for (const ch of 'this is a *test*') {
+        await page.keyboard.press(ch);
+        await page.waitForTimeout(50);
+    }
+    // Now type " hello" after the closing *
+    for (const ch of ' hello') {
+        await page.keyboard.press(ch === ' ' ? 'Space' : ch);
+        await page.waitForTimeout(50);
+    }
+    await page.waitForTimeout(100);
+
+    // Switch to source view to check the raw markdown
+    const { setSourceView } = await import('./test-utils.js');
+    await setSourceView(page);
+    const srcLine = page.locator('#editor .md-line').first();
+    const srcText = await srcLine.textContent();
+    // The raw markdown should have " hello" outside the italic markers
+    expect(srcText).toContain('*test*');
+    expect(srcText).toContain(' hello');
+    // " hello" must come after the closing *, not inside *...*
+    expect(srcText).toMatch(/\*test\* hello/);
+});
+
+test('typing after closing ** produces plain text, not bold', async () => {
+    await loadContent(page, '');
+    await setFocusedView(page);
+    const editor = page.locator('#editor');
+    await editor.click();
+    await page.waitForTimeout(100);
+
+    for (const ch of '**bold**') {
+        await page.keyboard.press(ch);
+        await page.waitForTimeout(50);
+    }
+    for (const ch of ' after') {
+        await page.keyboard.press(ch === ' ' ? 'Space' : ch);
+        await page.waitForTimeout(50);
+    }
+    await page.waitForTimeout(100);
+
+    const { setSourceView } = await import('./test-utils.js');
+    await setSourceView(page);
+    const srcLine = page.locator('#editor .md-line').first();
+    const srcText = await srcLine.textContent();
+    expect(srcText).toMatch(/\*\*bold\*\* after/);
+});
+
+test('typing after closing ~~ produces plain text, not strikethrough', async () => {
+    await loadContent(page, '');
+    await setFocusedView(page);
+    const editor = page.locator('#editor');
+    await editor.click();
+    await page.waitForTimeout(100);
+
+    for (const ch of '~~struck~~') {
+        await page.keyboard.press(ch);
+        await page.waitForTimeout(50);
+    }
+    for (const ch of ' after') {
+        await page.keyboard.press(ch === ' ' ? 'Space' : ch);
+        await page.waitForTimeout(50);
+    }
+    await page.waitForTimeout(100);
+
+    const { setSourceView } = await import('./test-utils.js');
+    await setSourceView(page);
+    const srcLine = page.locator('#editor .md-line').first();
+    const srcText = await srcLine.textContent();
+    expect(srcText).toMatch(/~~struck~~ after/);
+});

--- a/test/unit/editor/offset-mapping.test.js
+++ b/test/unit/editor/offset-mapping.test.js
@@ -1,0 +1,176 @@
+/**
+ * @fileoverview Unit tests for offset-mapping between raw markdown and
+ * rendered (visible) text.
+ *
+ * These tests verify that rawOffsetToRenderedOffset and
+ * renderedOffsetToRawOffset correctly handle both matched (invisible)
+ * and unmatched (visible) inline delimiters.
+ */
+
+// @ts-nocheck — test assertions access optional properties without guards
+
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import {
+    rawOffsetToRenderedOffset,
+    renderedOffsetToRawOffset,
+} from '../../../src/renderer/scripts/editor/offset-mapping.js';
+
+// ── rawOffsetToRenderedOffset ───────────────────────────────────────
+
+describe('rawOffsetToRenderedOffset', () => {
+    it('returns 0 for empty content', () => {
+        assert.equal(rawOffsetToRenderedOffset('', 5), 0);
+    });
+
+    it('returns identity for plain text', () => {
+        assert.equal(rawOffsetToRenderedOffset('hello world', 5), 5);
+        assert.equal(rawOffsetToRenderedOffset('hello world', 11), 11);
+    });
+
+    it('skips matched bold delimiters', () => {
+        // "a **b** c" — rendered as "a b c"
+        // raw:      a _ * * b * * _ c
+        // indices:  0 1 2 3 4 5 6 7 8
+        // rendered: a _ b _ c
+        // indices:  0 1 2 3 4
+        const content = 'a **b** c';
+        assert.equal(rawOffsetToRenderedOffset(content, 0), 0); // before 'a'
+        assert.equal(rawOffsetToRenderedOffset(content, 2), 2); // at '**' open
+        assert.equal(rawOffsetToRenderedOffset(content, 4), 2); // at 'b'
+        assert.equal(rawOffsetToRenderedOffset(content, 5), 3); // after 'b', at '**' close
+        assert.equal(rawOffsetToRenderedOffset(content, 7), 3); // after '**' close
+        assert.equal(rawOffsetToRenderedOffset(content, 9), 5); // end
+    });
+
+    it('skips matched italic delimiters', () => {
+        // "a *b* c" — rendered as "a b c"
+        const content = 'a *b* c';
+        assert.equal(rawOffsetToRenderedOffset(content, 2), 2); // at '*' open
+        assert.equal(rawOffsetToRenderedOffset(content, 3), 2); // at 'b'
+        assert.equal(rawOffsetToRenderedOffset(content, 4), 3); // at '*' close
+        assert.equal(rawOffsetToRenderedOffset(content, 5), 3); // after '*' close
+    });
+
+    it('treats unmatched * as visible text', () => {
+        // "this is a *" — the lone * is unmatched → visible
+        const content = 'this is a *';
+        // raw offset 10 = the '*', raw offset 11 = end
+        // rendered should be same as raw since '*' is visible
+        assert.equal(rawOffsetToRenderedOffset(content, 10), 10);
+        assert.equal(rawOffsetToRenderedOffset(content, 11), 11);
+    });
+
+    it('treats unmatched _ as visible text', () => {
+        const content = 'this is a _';
+        assert.equal(rawOffsetToRenderedOffset(content, 10), 10);
+        assert.equal(rawOffsetToRenderedOffset(content, 11), 11);
+    });
+
+    it('treats unmatched ~~ as visible text', () => {
+        const content = 'this is a ~~';
+        assert.equal(rawOffsetToRenderedOffset(content, 10), 10);
+        assert.equal(rawOffsetToRenderedOffset(content, 11), 11);
+        assert.equal(rawOffsetToRenderedOffset(content, 12), 12);
+    });
+
+    it('treats unmatched <sub> as visible text', () => {
+        const content = 'text <sub>';
+        // <sub> is unmatched (no </sub>) → visible
+        assert.equal(rawOffsetToRenderedOffset(content, 5), 5);
+        assert.equal(rawOffsetToRenderedOffset(content, 10), 10);
+    });
+
+    it('skips matched HTML tags', () => {
+        // "H<sub>2</sub>O" — rendered as "H2O"
+        const content = 'H<sub>2</sub>O';
+        assert.equal(rawOffsetToRenderedOffset(content, 0), 0); // 'H'
+        assert.equal(rawOffsetToRenderedOffset(content, 1), 1); // at '<sub>'
+        assert.equal(rawOffsetToRenderedOffset(content, 6), 1); // at '2'
+        assert.equal(rawOffsetToRenderedOffset(content, 7), 2); // at '</sub>'
+        assert.equal(rawOffsetToRenderedOffset(content, 13), 2); // at 'O'
+        assert.equal(rawOffsetToRenderedOffset(content, 14), 3); // end
+    });
+
+    it('handles code spans correctly', () => {
+        // "a `code` b" — backticks invisible, code content visible
+        const content = 'a `code` b';
+        assert.equal(rawOffsetToRenderedOffset(content, 2), 2); // at opening `
+        assert.equal(rawOffsetToRenderedOffset(content, 3), 2); // at 'c' in code
+        assert.equal(rawOffsetToRenderedOffset(content, 7), 6); // at closing `
+        assert.equal(rawOffsetToRenderedOffset(content, 8), 6); // after closing `
+    });
+
+    it('handles mixed matched and unmatched delimiters', () => {
+        // "**bold** and *" — ** matched, trailing * unmatched
+        const content = '**bold** and *';
+        // rendered: "bold and *"
+        // raw:  ** b o l d ** _ a n d _ *
+        //       01 2 3 4 5 67 8 9 ...    13
+        // rend:    b o l d    _ a n d _ *
+        //          0 1 2 3    4 5 6 7 8 9
+        assert.equal(rawOffsetToRenderedOffset(content, 2), 0); // at 'b'
+        assert.equal(rawOffsetToRenderedOffset(content, 6), 4); // after 'd'
+        assert.equal(rawOffsetToRenderedOffset(content, 13), 9); // at unmatched '*'
+        assert.equal(rawOffsetToRenderedOffset(content, 14), 10); // end
+    });
+});
+
+// ── renderedOffsetToRawOffset ───────────────────────────────────────
+
+describe('renderedOffsetToRawOffset', () => {
+    it('returns 0 for empty content', () => {
+        assert.equal(renderedOffsetToRawOffset('', 5), 0);
+    });
+
+    it('returns identity for plain text', () => {
+        assert.equal(renderedOffsetToRawOffset('hello world', 5), 5);
+    });
+
+    it('accounts for matched bold delimiters', () => {
+        // "a **b** c" — rendered as "a b c"
+        // At rendered boundaries the function returns the earliest raw
+        // position, which sits just before the invisible delimiter.
+        const content = 'a **b** c';
+        assert.equal(renderedOffsetToRawOffset(content, 0), 0); // 'a'
+        assert.equal(renderedOffsetToRawOffset(content, 2), 2); // end of "a ", before **
+        assert.equal(renderedOffsetToRawOffset(content, 3), 5); // after 'b', before closing **
+    });
+
+    it('treats unmatched * as visible text', () => {
+        // "this is a *" — the lone * is unmatched → visible
+        const content = 'this is a *';
+        assert.equal(renderedOffsetToRawOffset(content, 10), 10);
+        assert.equal(renderedOffsetToRawOffset(content, 11), 11);
+    });
+
+    it('treats unmatched ~~ as visible text', () => {
+        const content = 'this is a ~~';
+        assert.equal(renderedOffsetToRawOffset(content, 10), 10);
+        assert.equal(renderedOffsetToRawOffset(content, 12), 12);
+    });
+
+    it('treats unmatched <sub> as visible text', () => {
+        const content = 'text <sub>';
+        assert.equal(renderedOffsetToRawOffset(content, 5), 5);
+        assert.equal(renderedOffsetToRawOffset(content, 10), 10);
+    });
+
+    it('accounts for matched HTML tags', () => {
+        // "H<sub>2</sub>O" — rendered as "H2O"
+        const content = 'H<sub>2</sub>O';
+        assert.equal(renderedOffsetToRawOffset(content, 0), 0); // 'H'
+        assert.equal(renderedOffsetToRawOffset(content, 1), 1); // end of 'H', before <sub>
+        assert.equal(renderedOffsetToRawOffset(content, 2), 7); // after '2', before </sub>
+    });
+
+    it('handles mixed matched and unmatched delimiters', () => {
+        // "**bold** and *" — ** matched, trailing * unmatched
+        const content = '**bold** and *';
+        // rendered: "bold and *"
+        assert.equal(renderedOffsetToRawOffset(content, 0), 0); // before ** (early return)
+        assert.equal(renderedOffsetToRawOffset(content, 4), 6); // after 'd', before closing **
+        assert.equal(renderedOffsetToRawOffset(content, 9), 13); // at unmatched '*'
+        assert.equal(renderedOffsetToRawOffset(content, 10), 14); // end
+    });
+});


### PR DESCRIPTION
## Fix cursor jump when typing inline delimiters in focused view

Closes #44

### What was wrong

Typing `*`, `_`, `~~`, or `<sub>` after text in focused view caused the cursor to jump backwards instead of staying after the typed character. Additionally, typing text after a *closing* delimiter (e.g. typing after `*test*`) placed the new characters inside the formatted element instead of after it.

**Root cause 1 — unmatched delimiters treated as invisible:**
`rawOffsetToRenderedOffset` and `renderedOffsetToRawOffset` in `offset-mapping.js` treated *all* delimiter tokens (`italic-open`, `html-open`, etc.) as invisible formatting markers. But `buildInlineTree` in `inline-tokenizer.js` collapses unmatched delimiters back to visible plain text. So typing a lone `*` produced a token the offset mapper skipped, mapping raw offset 11 → rendered offset 10 — the cursor jumped left.

**Root cause 2 — no forward affinity at formatting boundaries:**
After typing a closing delimiter (completing `*test*`), `placeCursor` placed the caret at offset 4 inside the `<em>`'s text node because `remaining <= len` matched. `syncCursorFromDOM` then mapped that back to a raw offset *before* the closing `*`, so subsequent keystrokes went inside the formatted range.

### What changed

1. **`inline-tokenizer.js`** — Added `findMatchedTokenIndices(tokens)` which mirrors `buildInlineTree`'s pairing logic and returns a `Set<number>` of token indices that are successfully paired (open ↔ close).

2. **`offset-mapping.js`** — Both `rawOffsetToRenderedOffset` and `renderedOffsetToRawOffset` now check `findMatchedTokenIndices` for each delimiter token. Matched delimiters are invisible (advance raw only); unmatched delimiters are visible (advance both raw and rendered).

3. **`focused-renderer.js`** — `appendSegments` now inserts an empty text node after every formatting element (`<em>`, `<strong>`, `<del>`, `<code>`, `<a>`, HTML inline tags). This gives the TreeWalker a landing spot outside the element.

4. **`cursor-manager.js`** — `placeCursor` uses strict `<` instead of `<=` for forward affinity at formatting boundaries. Added `_isOutsideFormatting` helper and enhanced `_toRawOffset` to advance past invisible closing delimiters when the cursor is outside all formatting wrappers in the DOM.

### Tests added

- **Unit tests** (`test/unit/editor/offset-mapping.test.js`): 22 tests covering `rawOffsetToRenderedOffset` and `renderedOffsetToRawOffset` for matched delimiters, unmatched delimiters, code spans, HTML tags, and mixed scenarios.
- **Unit tests** (`test/unit/parser/inline-tokenizer.test.js`): 8 tests for `findMatchedTokenIndices`.
- **Integration tests** (`test/integration/cursor-typing-delimiters.spec.js`): 9 tests covering cursor position after typing `*`, `_`, `~~`, `<sub>`, completing `**bold**` and `*italic*`, and verifying that text typed after closing `*`, `**`, and `~~` is plain (not formatted).