### PR TITLE
feat: highlight active ToC section on scroll (issue #42)

### DIFF
--- a/docs/developers/ai-agent-notes.md
+++ b/docs/developers/ai-agent-notes.md
@@ -58,8 +58,11 @@ this **before** doing any work.
   and write a PR comment **in raw markdown source code** inside a
   fenced code block (` ```markdown ... ``` `), **never** as styled /
   rendered text, that documents what was wrong, how it got changed and
-  why it needed that specific change.   Make sure to also note that the
+  why it needed that specific change. Make sure to also note that the
   PR closes the issue number, if the work was part of addressing an issue.
+- **Never** hard-wrap markdown text at a fixed column width. Write each
+  paragraph or list item as a single long line and let the viewer handle
+  wrapping.
 - Note that any changes to this file should **always** be added to git
   commits. They should never be backed out or unstaged.
 

--- a/src/renderer/styles/toc.css
+++ b/src/renderer/styles/toc.css
@@ -117,6 +117,12 @@
     text-decoration: none;
 }
 
+.toc-link.toc-active {
+    background: var(--color-bg-secondary);
+    color: var(--color-primary);
+    font-weight: 600;
+}
+
 .toc-link:focus-visible {
     outline: 2px solid var(--color-primary);
     outline-offset: -1px;
@@ -136,7 +142,8 @@
     color: var(--color-text-secondary);
 }
 
-.toc-level-3 > .toc-link:hover {
+.toc-level-3 > .toc-link:hover,
+.toc-level-3 > .toc-link.toc-active {
     color: var(--color-primary);
 }
 

--- a/test/fixtures/many-sections.md
+++ b/test/fixtures/many-sections.md
@@ -1,0 +1,121 @@
+# Many Sections
+
+## Section 1
+
+Content for section 1. Lorem ipsum dolor sit amet.
+
+## Section 2
+
+Content for section 2. Lorem ipsum dolor sit amet.
+
+## Section 3
+
+Content for section 3. Lorem ipsum dolor sit amet.
+
+## Section 4
+
+Content for section 4. Lorem ipsum dolor sit amet.
+
+## Section 5
+
+Content for section 5. Lorem ipsum dolor sit amet.
+
+## Section 6
+
+Content for section 6. Lorem ipsum dolor sit amet.
+
+## Section 7
+
+Content for section 7. Lorem ipsum dolor sit amet.
+
+## Section 8
+
+Content for section 8. Lorem ipsum dolor sit amet.
+
+## Section 9
+
+Content for section 9. Lorem ipsum dolor sit amet.
+
+## Section 10
+
+Content for section 10. Lorem ipsum dolor sit amet.
+
+## Section 11
+
+Content for section 11. Lorem ipsum dolor sit amet.
+
+## Section 12
+
+Content for section 12. Lorem ipsum dolor sit amet.
+
+## Section 13
+
+Content for section 13. Lorem ipsum dolor sit amet.
+
+## Section 14
+
+Content for section 14. Lorem ipsum dolor sit amet.
+
+## Section 15
+
+Content for section 15. Lorem ipsum dolor sit amet.
+
+## Section 16
+
+Content for section 16. Lorem ipsum dolor sit amet.
+
+## Section 17
+
+Content for section 17. Lorem ipsum dolor sit amet.
+
+## Section 18
+
+Content for section 18. Lorem ipsum dolor sit amet.
+
+## Section 19
+
+Content for section 19. Lorem ipsum dolor sit amet.
+
+## Section 20
+
+Content for section 20. Lorem ipsum dolor sit amet.
+
+## Section 21
+
+Content for section 21. Lorem ipsum dolor sit amet.
+
+## Section 22
+
+Content for section 22. Lorem ipsum dolor sit amet.
+
+## Section 23
+
+Content for section 23. Lorem ipsum dolor sit amet.
+
+## Section 24
+
+Content for section 24. Lorem ipsum dolor sit amet.
+
+## Section 25
+
+Content for section 25. Lorem ipsum dolor sit amet.
+
+## Section 26
+
+Content for section 26. Lorem ipsum dolor sit amet.
+
+## Section 27
+
+Content for section 27. Lorem ipsum dolor sit amet.
+
+## Section 28
+
+Content for section 28. Lorem ipsum dolor sit amet.
+
+## Section 29
+
+Content for section 29. Lorem ipsum dolor sit amet.
+
+## Section 30
+
+Content for section 30. Lorem ipsum dolor sit amet.

--- a/test/integration/toc-highlight.spec.js
+++ b/test/integration/toc-highlight.spec.js
@@ -1,0 +1,205 @@
+/**
+ * @fileoverview Integration test for the ToC scroll-spy highlighting.
+ *
+ * Verifies that as the user scrolls through the document, the ToC
+ * sidebar highlights the heading whose section occupies the most
+ * visible area in the viewport.
+ */
+
+import { readFile } from 'node:fs/promises';
+import { createServer } from 'node:http';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { expect, test } from '@playwright/test';
+import { clickInEditor } from './test-utils.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const RENDERER_DIR = path.join(__dirname, '..', '..', 'src', 'renderer');
+const FIXTURES_DIR = path.join(__dirname, '..', 'fixtures');
+
+/** @type {Record<string, string>} */
+const CONTENT_TYPES = {
+    '.html': 'text/html',
+    '.js': 'application/javascript',
+    '.css': 'text/css',
+};
+
+/** @type {import('node:http').Server} */
+let server;
+
+/** @type {string} */
+let baseURL;
+
+test.beforeAll(async () => {
+    server = createServer(async (req, res) => {
+        let urlPath = new URL(req.url ?? '/', 'http://localhost').pathname;
+        if (urlPath === '/') urlPath = '/index.html';
+        const filePath = path.resolve(path.join(RENDERER_DIR, urlPath));
+
+        if (!filePath.startsWith(RENDERER_DIR)) {
+            res.writeHead(403);
+            res.end('Forbidden');
+            return;
+        }
+
+        try {
+            const content = await readFile(filePath);
+            const ext = path.extname(filePath);
+            res.writeHead(200, {
+                'Content-Type': CONTENT_TYPES[ext] || 'application/octet-stream',
+            });
+            res.end(content);
+        } catch {
+            res.writeHead(404);
+            res.end('Not Found');
+        }
+    });
+
+    await new Promise((resolve) => server.listen(0, /** @type {() => void} */ (resolve)));
+    const addr = /** @type {import('node:net').AddressInfo} */ (server.address());
+    baseURL = `http://localhost:${addr.port}`;
+});
+
+test.afterAll(async () => {
+    if (server) {
+        await new Promise((resolve) => server.close(resolve));
+    }
+});
+
+/**
+ * Reads the lorem ipsum fixture file.
+ * @returns {Promise<string>}
+ */
+async function loadLoremFixture() {
+    return readFile(path.join(FIXTURES_DIR, 'lorem.md'), 'utf-8');
+}
+
+/**
+ * Reads the many-sections fixture file.
+ * @returns {Promise<string>}
+ */
+async function loadManySectionsFixture() {
+    return readFile(path.join(FIXTURES_DIR, 'many-sections.md'), 'utf-8');
+}
+
+test('ToC highlights the heading whose section fills most of the viewport', async ({ page }) => {
+    await page.goto(baseURL);
+    await page.waitForSelector('#editor .md-line');
+
+    const editor = page.locator('#editor');
+    await clickInEditor(page, editor);
+
+    // Load the lorem fixture — it has multiple chapters with lots of content
+    const content = await loadLoremFixture();
+    await page.evaluate((md) => window.editorAPI?.setContent(md), content);
+    await page.waitForSelector('#toc-sidebar .toc-link');
+
+    // Scroll to the top — "Main text" section should dominate the viewport
+    await page.evaluate(() => {
+        const container = document.getElementById('editor-container');
+        if (container) container.scrollTop = 0;
+    });
+    await page.waitForTimeout(100);
+
+    // The first real content section is under "Lorem Ipsum" (h1).
+    // Its content should dominate the viewport at scroll-top.
+    const activeLink = page.locator('#toc-sidebar .toc-link.toc-active');
+    await expect(activeLink).toHaveCount(1);
+    const initialText = await activeLink.textContent();
+    // Should be either "Lorem Ipsum" or "Main text" depending on
+    // which section's content is most visible at the top.
+    expect(['Lorem Ipsum', 'Main text']).toContain(initialText);
+
+    // Now scroll so that Chapter 5 content fills most of the viewport.
+    await page.evaluate((text) => {
+        const container = document.getElementById('editor-container');
+        const lines = document.querySelectorAll('#editor > .md-line');
+        for (const line of lines) {
+            if (line.textContent?.includes(text)) {
+                const containerRect = container?.getBoundingClientRect();
+                const lineRect = line.getBoundingClientRect();
+                if (container && containerRect) {
+                    container.scrollTop += lineRect.top - containerRect.top;
+                }
+                break;
+            }
+        }
+    }, 'Chapter 5');
+    await page.waitForTimeout(100);
+
+    // Now Chapter 5 should be the active heading
+    const activeAfterScroll = page.locator('#toc-sidebar .toc-link.toc-active');
+    await expect(activeAfterScroll).toHaveCount(1);
+    await expect(activeAfterScroll).toHaveText('Chapter 5');
+});
+
+test('ToC highlight updates when scrolling between sections', async ({ page }) => {
+    await page.goto(baseURL);
+    await page.waitForSelector('#editor .md-line');
+
+    const editor = page.locator('#editor');
+    await clickInEditor(page, editor);
+
+    const content = await loadLoremFixture();
+    await page.evaluate((md) => window.editorAPI?.setContent(md), content);
+    await page.waitForSelector('#toc-sidebar .toc-link');
+
+    // Scroll to bottom of the document
+    await page.evaluate(() => {
+        const container = document.getElementById('editor-container');
+        if (container) container.scrollTop = container.scrollHeight;
+    });
+    await page.waitForTimeout(100);
+
+    // The last chapter's content should dominate; the active link should
+    // NOT be "Chapter 1"
+    const activeLink = page.locator('#toc-sidebar .toc-link.toc-active');
+    await expect(activeLink).toHaveCount(1);
+    const activeText = await activeLink.textContent();
+    expect(activeText).not.toBe('Lorem Ipsum');
+    expect(activeText).not.toBe('Main text');
+});
+
+test('active ToC link is scrolled to the vertical center of the sidebar', async ({ page }) => {
+    await page.goto(baseURL);
+    await page.waitForSelector('#editor .md-line');
+
+    const editor = page.locator('#editor');
+    await clickInEditor(page, editor);
+
+    // Build a document with many headings so the ToC itself overflows.
+    const md = await loadManySectionsFixture();
+    await page.evaluate((content) => window.editorAPI?.setContent(content), md);
+    await page.waitForSelector('#toc-sidebar .toc-link');
+
+    // Scroll the editor to the very bottom so that the last section is active.
+    await page.evaluate(() => {
+        const container = document.getElementById('editor-container');
+        if (container) container.scrollTop = container.scrollHeight;
+    });
+    await page.waitForTimeout(100);
+
+    // The active link should be one of the last sections.
+    const activeLink = page.locator('#toc-sidebar .toc-link.toc-active');
+    await expect(activeLink).toHaveCount(1);
+
+    // Verify the active link is roughly centered in the ToC sidebar.
+    const positions = await page.evaluate(() => {
+        const toc = document.getElementById('toc-sidebar');
+        const active = toc?.querySelector('.toc-link.toc-active');
+        if (!toc || !active) return null;
+        const tocRect = toc.getBoundingClientRect();
+        const linkRect = active.getBoundingClientRect();
+        const linkCenter = linkRect.top + linkRect.height / 2;
+        const tocCenter = tocRect.top + tocRect.height / 2;
+        return { linkCenter, tocCenter, tocHeight: tocRect.height };
+    });
+
+    expect(positions).not.toBeNull();
+    const p = /** @type {NonNullable<typeof positions>} */ (positions);
+    // The active link's center should be within 40% of the ToC's center.
+    // (Some leeway because the last item can't scroll past the bottom.)
+    const tolerance = p.tocHeight * 0.4;
+    expect(Math.abs(p.linkCenter - p.tocCenter)).toBeLessThanOrEqual(tolerance);
+});


### PR DESCRIPTION
# Highlight active ToC section on scroll (issue #42)

Closes #42

## Problem

As the user scrolled through their document, the ToC sidebar gave no indication of which section was currently on screen. There was no way to tell at a glance where you were in a long document without a heading being visible.

## Solution

Added a scroll-spy to the ToC that highlights the heading whose **content occupies the most visible area** in the viewport. This is based on all visible content elements, not just heading positions — if 80% of the viewport is filled with Chapter 3 content and a Chapter 4 heading just appeared at the bottom, the ToC correctly highlights Chapter 3.

### How it works

1. On every `refresh()` (triggered by the existing `MutationObserver`), the ToC walks the full syntax tree in document order and builds a map from every node ID to the ID of the h1–h3 heading whose section it belongs to.
2. A passive `scroll` listener on `#editor-container` fires `_updateActiveHeading()`, which iterates the editor's direct child elements, computes how many visible pixels each contributes within the scroll container, and buckets them by owning heading.
3. The heading with the most visible pixels gets a `.toc-active` CSS class on its ToC link; all others have it removed.
4. When the active link changes, the ToC sidebar scrolls itself so the active link is centered vertically — important for long documents with many headings where the ToC itself overflows.

### Changed files

- **`src/renderer/scripts/toc/toc.js`** — Added `_nodeToHeadingId` map, `_buildNodeToHeadingMap()`, `_updateActiveHeading()` (with ToC auto-scroll-to-center), passive scroll listener setup in `initialize()`, cleanup in `destroy()`.
- **`src/renderer/styles/toc.css`** — Added `.toc-link.toc-active` style and ensured h3 links also get the active color via `.toc-level-3 > .toc-link.toc-active`.
- **`docs/developers/ai-agent-notes.md`** — Added "never hard-wrap markdown" convention.

### Tests

- **`test/integration/toc-highlight.spec.js`** — Three tests: (1) highlight switches from the first section to Chapter 5 when scrolling, (2) scrolling to the bottom highlights something other than the first section, (3) the active ToC link is scrolled to the vertical center of the sidebar when the ToC overflows.
- **`test/fixtures/many-sections.md`** — 30-section fixture used by the ToC auto-scroll test.