### PR TITLE
Cycle select-all through node/parent/document, remove empty elements on delete

### DIFF
--- a/src/renderer/scripts/editor/event-handler.js
+++ b/src/renderer/scripts/editor/event-handler.js
@@ -54,6 +54,7 @@ export class EventHandler {
      * @param {MouseEvent} event
      */
     handleClick(event) {
+        this.editor.rangeOperations.resetSelectAllLevel();
         this.editor.syncCursorFromDOM();
 
         // Clicking on replaced/void elements like <img> or <hr> doesn't

--- a/src/renderer/scripts/editor/input-handler.js
+++ b/src/renderer/scripts/editor/input-handler.js
@@ -51,6 +51,7 @@ export class InputHandler {
             if (this.editor.treeRange) {
                 const rangeResult = this.editor.rangeOperations.deleteSelectedRange();
                 if (rangeResult) {
+                    this.editor.editOperations._cleanupEmptyNodeAfterDelete(rangeResult);
                     this.editor.recordAndRender(rangeResult.before, rangeResult.hints);
                 }
             }
@@ -68,6 +69,19 @@ export class InputHandler {
      * @param {KeyboardEvent} event
      */
     handleKeyDown(event) {
+        // Reset select-all cycling for any key that is not Ctrl/Cmd+A
+        // and not a bare modifier key (pressing Ctrl alone should not
+        // reset the cycle so that repeated Ctrl+A works).
+        const isSelectAll = (event.ctrlKey || event.metaKey) && event.key === 'a';
+        const isModifierOnly =
+            event.key === 'Control' ||
+            event.key === 'Shift' ||
+            event.key === 'Alt' ||
+            event.key === 'Meta';
+        if (!isSelectAll && !isModifierOnly) {
+            this.editor.rangeOperations.resetSelectAllLevel();
+        }
+
         // ── Undo / Redo ──
         if (event.ctrlKey || event.metaKey) {
             if (event.key === 'z' && !event.shiftKey) {

--- a/test/integration/list.spec.js
+++ b/test/integration/list.spec.js
@@ -315,13 +315,10 @@ test('Enter on empty middle ordered item renumbers remaining items', async () =>
     await line.click();
     await page.waitForTimeout(200);
 
-    // Select all text in Beta and delete it
+    // Select all text in Beta and delete it — the empty item is removed
+    // automatically and remaining items are renumbered.
     await page.keyboard.press(`${MOD}+a`);
     await page.keyboard.press('Backspace');
-    await page.waitForTimeout(200);
-
-    // Now press Enter on the empty item to exit the list
-    await page.keyboard.press('Enter');
     await page.waitForTimeout(200);
 
     await setSourceView(page);
@@ -329,11 +326,9 @@ test('Enter on empty middle ordered item renumbers remaining items', async () =>
     const lines = page.locator('#editor .md-line');
     const first = await lines.nth(0).textContent();
     const second = await lines.nth(1).textContent();
-    const third = await lines.nth(2).textContent();
-    // Alpha keeps its number, Beta is now a plain paragraph, Gamma renumbered to 2
+    // Alpha keeps its number, Gamma renumbered to 2 (Beta was removed)
     expect(first).toMatch(/^1\. Alpha/);
-    expect(second?.trim()).toBe('');
-    expect(third).toMatch(/^2\. Gamma/);
+    expect(second).toMatch(/^2\. Gamma/);
 });
 
 test('pasting multi-line markdown with list items creates correct nodes', async () => {

--- a/test/integration/select-all.spec.js
+++ b/test/integration/select-all.spec.js
@@ -1,0 +1,216 @@
+/**
+ * @fileoverview Integration tests for Ctrl+A select-all cycling and
+ * delete/backspace removal of empty elements after selection delete.
+ */
+
+import { expect, test } from '@playwright/test';
+import { MOD, clickInEditor, launchApp, loadContent } from './test-utils.js';
+
+/** @type {import('@playwright/test').ElectronApplication} */
+let electronApp;
+
+/** @type {import('@playwright/test').Page} */
+let page;
+
+test.beforeAll(async () => {
+    ({ electronApp, page } = await launchApp());
+});
+
+test.afterAll(async () => {
+    await electronApp.close();
+});
+
+// ── Select-All Cycling ──
+
+test.describe('Select-All Cycling', () => {
+    test('first Ctrl+A selects current paragraph content', async () => {
+        await loadContent(page, 'Hello world\n\nSecond paragraph');
+        const editor = page.locator('#editor');
+
+        // Click into the first paragraph
+        const firstLine = editor.locator('.md-line', { hasText: 'Hello world' }).first();
+        await clickInEditor(page, firstLine);
+
+        // First Ctrl+A — selects the paragraph
+        await page.keyboard.press(`${MOD}+a`);
+
+        const selectedText = await page.evaluate(() => window.getSelection()?.toString());
+        expect(selectedText).toBe('Hello world');
+    });
+
+    test('second Ctrl+A on paragraph (no parent) selects entire document', async () => {
+        await loadContent(page, 'Hello world\n\nSecond paragraph');
+        const editor = page.locator('#editor');
+
+        const firstLine = editor.locator('.md-line', { hasText: 'Hello world' }).first();
+        await clickInEditor(page, firstLine);
+
+        // First Ctrl+A — selects the paragraph
+        await page.keyboard.press(`${MOD}+a`);
+        // Second Ctrl+A — no parent group, so selects entire document
+        await page.keyboard.press(`${MOD}+a`);
+
+        const selectedText = await page.evaluate(() => window.getSelection()?.toString());
+        // Should contain content from both paragraphs
+        expect(selectedText).toContain('Hello world');
+        expect(selectedText).toContain('Second paragraph');
+    });
+
+    test('first Ctrl+A on list item selects item, second selects list run', async () => {
+        await loadContent(page, 'Before\n\n- apple\n- banana\n- cherry\n\nAfter');
+        const editor = page.locator('#editor');
+
+        // Click into the "banana" list item
+        const bananaLine = editor.locator('.md-line', { hasText: 'banana' }).first();
+        await clickInEditor(page, bananaLine);
+
+        // First Ctrl+A — selects just "banana"
+        await page.keyboard.press(`${MOD}+a`);
+        let selectedText = await page.evaluate(() => window.getSelection()?.toString());
+        expect(selectedText).toBe('banana');
+
+        // Second Ctrl+A — selects the entire list run
+        await page.keyboard.press(`${MOD}+a`);
+        selectedText = await page.evaluate(() => window.getSelection()?.toString());
+        expect(selectedText).toContain('apple');
+        expect(selectedText).toContain('banana');
+        expect(selectedText).toContain('cherry');
+    });
+
+    test('third Ctrl+A on list item selects entire document', async () => {
+        await loadContent(page, 'Before\n\n- apple\n- banana\n- cherry\n\nAfter');
+        const editor = page.locator('#editor');
+
+        const bananaLine = editor.locator('.md-line', { hasText: 'banana' }).first();
+        await clickInEditor(page, bananaLine);
+
+        await page.keyboard.press(`${MOD}+a`);
+        await page.keyboard.press(`${MOD}+a`);
+        await page.keyboard.press(`${MOD}+a`);
+
+        const selectedText = await page.evaluate(() => window.getSelection()?.toString());
+        expect(selectedText).toContain('Before');
+        expect(selectedText).toContain('After');
+    });
+
+    test('clicking resets the cycling level', async () => {
+        await loadContent(page, 'Hello world\n\nSecond paragraph');
+        const editor = page.locator('#editor');
+
+        const firstLine = editor.locator('.md-line', { hasText: 'Hello world' }).first();
+        await clickInEditor(page, firstLine);
+
+        // Ctrl+A then click → resets, next Ctrl+A should select node again
+        await page.keyboard.press(`${MOD}+a`);
+        await clickInEditor(page, firstLine);
+        await page.keyboard.press(`${MOD}+a`);
+
+        const selectedText = await page.evaluate(() => window.getSelection()?.toString());
+        expect(selectedText).toBe('Hello world');
+    });
+
+    test('first Ctrl+A on heading selects heading content', async () => {
+        await loadContent(page, '## My Heading\n\nSome text');
+        const editor = page.locator('#editor');
+
+        const heading = editor.locator('.md-line', { hasText: 'My Heading' }).first();
+        await clickInEditor(page, heading);
+
+        await page.keyboard.press(`${MOD}+a`);
+
+        const selectedText = await page.evaluate(() => window.getSelection()?.toString());
+        expect(selectedText).toBe('My Heading');
+    });
+});
+
+// ── Delete/Backspace Removes Empty Elements ──
+
+test.describe('Delete Empty Elements', () => {
+    test('Ctrl+A then Backspace on single paragraph removes it, leaves empty doc', async () => {
+        await loadContent(page, 'Only paragraph');
+        const editor = page.locator('#editor');
+
+        const line = editor.locator('.md-line').first();
+        await clickInEditor(page, line);
+
+        await page.keyboard.press(`${MOD}+a`);
+        await page.keyboard.press('Backspace');
+
+        // Document should have a single empty paragraph (not a lingering empty heading etc.)
+        const content = await page.evaluate(() => window.editorAPI?.getContent());
+        expect(content?.trim()).toBe('');
+
+        // Should still have one editable line in the DOM
+        const lineCount = await editor.locator('.md-line').count();
+        expect(lineCount).toBe(1);
+    });
+
+    test('Ctrl+A then Delete on heading removes it, cursor moves to adjacent node', async () => {
+        await loadContent(page, '## Heading\n\nNext paragraph');
+        const editor = page.locator('#editor');
+
+        const heading = editor.locator('.md-line', { hasText: 'Heading' }).first();
+        await clickInEditor(page, heading);
+
+        await page.keyboard.press(`${MOD}+a`);
+        await page.keyboard.press('Delete');
+
+        const content = await page.evaluate(() => window.editorAPI?.getContent());
+        // The heading should be gone, only the paragraph remains
+        expect(content).not.toContain('## Heading');
+        expect(content).not.toContain('Heading');
+        expect(content?.trim()).toContain('Next paragraph');
+    });
+
+    test('Ctrl+A then Backspace on list item removes it from list', async () => {
+        await loadContent(page, '- first\n- second\n- third');
+        const editor = page.locator('#editor');
+
+        const secondItem = editor.locator('.md-line', { hasText: 'second' }).first();
+        await clickInEditor(page, secondItem);
+
+        await page.keyboard.press(`${MOD}+a`);
+        await page.keyboard.press('Backspace');
+
+        const content = await page.evaluate(() => window.editorAPI?.getContent());
+        expect(content).not.toContain('second');
+        expect(content).toContain('first');
+        expect(content).toContain('third');
+    });
+
+    test('Ctrl+A then Backspace on blockquote removes it', async () => {
+        await loadContent(page, 'Before\n\n> Quoted text\n\nAfter');
+        const editor = page.locator('#editor');
+
+        const quote = editor.locator('.md-line', { hasText: 'Quoted text' }).first();
+        await clickInEditor(page, quote);
+
+        await page.keyboard.press(`${MOD}+a`);
+        await page.keyboard.press('Backspace');
+
+        const content = await page.evaluate(() => window.editorAPI?.getContent());
+        expect(content).not.toContain('Quoted text');
+        expect(content).toContain('Before');
+        expect(content).toContain('After');
+    });
+
+    test('select-all document then delete leaves single empty paragraph', async () => {
+        await loadContent(page, '## Heading\n\nParagraph\n\n- item');
+        const editor = page.locator('#editor');
+
+        const heading = editor.locator('.md-line', { hasText: 'Heading' }).first();
+        await clickInEditor(page, heading);
+
+        // Cycle to document-level select-all
+        await page.keyboard.press(`${MOD}+a`);
+        await page.keyboard.press(`${MOD}+a`);
+        await page.keyboard.press('Delete');
+
+        const content = await page.evaluate(() => window.editorAPI?.getContent());
+        expect(content?.trim()).toBe('');
+
+        // Document should still have one line element
+        const lineCount = await editor.locator('.md-line').count();
+        expect(lineCount).toBe(1);
+    });
+});


### PR DESCRIPTION
## Select-all cycling and empty-element removal (closes #55)

### What changed

**Ctrl+A now cycles through three selection levels:**

1. **Node** — selects the content of the current block-level element (paragraph, heading, list item, blockquote, code block, table cell)
2. **Parent group** — if the node belongs to a content parent (list items select the entire contiguous list run; html-block children select all siblings within the container). Nodes without a parent group skip this level.
3. **Document** — selects the entire document content

The cycling level resets on any non-Ctrl+A keypress or mouse click.

**Delete/Backspace on a selection now removes empty elements:**

After deleting a selection, if the surviving node is empty and is a removable type (paragraph, heading, blockquote, list-item, code-block, table, html-block), it is removed from the tree entirely rather than left as an empty shell. If this empties the document, a fresh empty paragraph is inserted. When a list item is removed, adjacent ordered list items are renumbered.

### Why

Previously Ctrl+A only selected the current node with no way to expand the selection further. Users had no keyboard-driven path to select an entire list or the whole document. Empty elements left behind after deletion cluttered the document and required manual cleanup.

### Files changed

- `src/renderer/scripts/editor/range-operations.js` — rewrote `handleSelectAll()` with cycling state (`_selectAllLevel`), added `_selectNode`, `_selectContentParent`, `_selectDocument`, `_selectNodeRange`, `_hasContentParent`, `_firstLeaf`, `_lastLeaf` helpers
- `src/renderer/scripts/editor/edit-operations.js` — added `REMOVABLE_WHEN_EMPTY` set and `_cleanupEmptyNodeAfterDelete()` method, wired into `handleBackspace` and `handleDelete` range-delete paths; includes ordered-list renumbering on item removal
- `src/renderer/scripts/editor/input-handler.js` — resets cycling level on non-Ctrl+A, non-modifier keydowns; wires cleanup into `deleteByCut` handler
- `src/renderer/scripts/editor/event-handler.js` — resets cycling level on mouse click
- `test/integration/select-all.spec.js` — 11 new tests covering cycling for paragraphs, headings, list items, click reset, and empty-element removal for paragraphs, headings, list items, blockquotes, and full-document delete
- `test/integration/list.spec.js` — updated "Enter on empty middle ordered item renumbers remaining items" to match new behavior (empty item is removed immediately on Backspace rather than waiting for Enter)
