### PR TITLE
Add search feature with plain text and regex support (closes #57)

### DIFF
--- a/docs/developers/ai-agent-notes.md
+++ b/docs/developers/ai-agent-notes.md
@@ -53,13 +53,15 @@ this **before** doing any work.
   `git push origin <branchname>`. Never use bare `git push` or
   `--set-upstream`.
 - Do not consider the work done until a final full test suite run passes.
-- After the work has been completed (as agreed to by the user), form a
-  final commit (**only after the full test suite confirms everything works**)
-  and write a PR comment **in raw markdown source code** inside a
-  fenced code block (` ```markdown ... ``` `), **never** as styled /
-  rendered text, that documents what was wrong, how it got changed and
-  why it needed that specific change. Make sure to also note that the
-  PR closes the issue number, if the work was part of addressing an issue.
+- After the work has been completed **ask the user to manually test the work**.
+- After testing finishes, update the docs to ensure they're still correct
+  with respect to the current code.
+- Once code, tests, and docs are all done, form a final commit and write
+  a PR comment **in raw markdown source code** inside a fenced code block
+  (` ```markdown ... ``` `), **never** as styled / rendered text, that
+  documents what was wrong, how it got changed and why it needed that
+  specific change. Make sure to also note that the PR closes the issue
+  number, if the work was part of addressing an issue.
 - **Never** hard-wrap markdown text at a fixed column width. Write each
   paragraph or list item as a single long line and let the viewer handle
   wrapping.

--- a/docs/developers/design.md
+++ b/docs/developers/design.md
@@ -109,7 +109,8 @@ src/
 │   │   ├── table.css        # Table dialog and element styles
 │   │   ├── toc.css          # Table of Contents sidebar styles
 │   │   ├── preferences.css  # Preferences modal styles
-│   │   └── word-count.css   # Word count modal styles
+│   │   ├── word-count.css   # Word count modal styles
+│   │   └── search.css       # Search panel styles
 │   │
 │   └── scripts/              # JavaScript
 │       ├── app.js           # App entry, wires components together
@@ -150,6 +151,8 @@ src/
 │       │   └── toc.js
 │       ├── preferences/     # Preferences modal
 │       │   └── preferences-modal.js
+│       ├── search/          # Search panel
+│       │   └── search-bar.js
 │       └── word-count/      # Word count modal
 │           └── word-count-modal.js
 │
@@ -178,6 +181,7 @@ test/
     ├── backspace-heading-to-paragraph.spec.js
     ├── image.spec.js
     ├── load-images.spec.js
+    ├── search.spec.js
     ├── table.spec.js
     ├── toc-scroll.spec.js
     ├── toolbar-tooltip.spec.js

--- a/docs/developers/getting-started.md
+++ b/docs/developers/getting-started.md
@@ -61,6 +61,7 @@ markdown-editor/
 │       │   ├── toc.css
 │       │   ├── preferences.css
 │       │   ├── word-count.css
+│       │   ├── search.css
 │       │   └── tab-bar.css
 │       └── scripts/
 │           ├── app.js           # Renderer entry point
@@ -72,6 +73,7 @@ markdown-editor/
 │           ├── table/           # Table insert/edit modal
 │           ├── tab-bar/         # Multi-file tab bar
 │           ├── toc/             # Table of Contents sidebar
+│           ├── search/          # Search panel
 │           ├── preferences/     # Preferences modal
 │           └── word-count/      # Word count modal
 │

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -15,6 +15,7 @@
     <link rel="stylesheet" href="styles/toc.css">
     <link rel="stylesheet" href="styles/word-count.css">
     <link rel="stylesheet" href="styles/tab-bar.css">
+    <link rel="stylesheet" href="styles/search.css">
 </head>
 <body>
     <div id="app">

--- a/src/renderer/scripts/app.js
+++ b/src/renderer/scripts/app.js
@@ -12,6 +12,7 @@ import { initPageResizeHandles } from './editor/page-resize.js';
 import { KeyboardHandler } from './handlers/keyboard-handler.js';
 import { MenuHandler } from './handlers/menu-handler.js';
 import { applyColors, applyMargins, applyPageWidth } from './preferences/preferences-modal.js';
+import { SearchBar } from './search/search-bar.js';
 import { TabBar, getDisambiguatedLabels } from './tab-bar/tab-bar.js';
 import { TableOfContents } from './toc/toc.js';
 import { Toolbar } from './toolbar/toolbar.js';
@@ -45,6 +46,9 @@ class App {
 
         /** @type {KeyboardHandler|null} */
         this.keyboardHandler = null;
+
+        /** @type {SearchBar|null} */
+        this.searchBar = null;
 
         /** @type {TableOfContents|null} */
         this.toc = null;
@@ -96,6 +100,14 @@ class App {
 
         this.keyboardHandler = new KeyboardHandler(this.editor);
         this.keyboardHandler.initialize();
+
+        // Initialize search bar
+        this.searchBar = new SearchBar(this.editor);
+        this.searchBar.initialize();
+
+        document.addEventListener('search:open', () => {
+            this.searchBar?.open();
+        });
 
         // Initialize Table of Contents sidebar
         if (tocContainer) {

--- a/src/renderer/scripts/editor/editor.js
+++ b/src/renderer/scripts/editor/editor.js
@@ -303,6 +303,7 @@ export class Editor {
         } finally {
             this._isRendering = false;
         }
+        document.dispatchEvent(new CustomEvent('editor:renderComplete'));
     }
 
     /**
@@ -322,6 +323,7 @@ export class Editor {
             } finally {
                 this._isRendering = false;
             }
+            document.dispatchEvent(new CustomEvent('editor:renderComplete'));
         } else {
             this.fullRender();
         }
@@ -485,7 +487,10 @@ export class Editor {
      * @param {string} markdown - The markdown content to load
      */
     loadMarkdown(markdown) {
-        this.syntaxTree = this.parser.parse(markdown);
+        // Normalise excessive blank lines so that toMarkdown() / toBareText()
+        // always produce exactly one blank line between blocks.
+        const normalised = markdown.replace(/\n{3,}/g, '\n\n');
+        this.syntaxTree = this.parser.parse(normalised);
 
         // Ensure there is at least one node so the editor is never empty
         if (this.syntaxTree.children.length === 0) {

--- a/src/renderer/scripts/handlers/keyboard-handler.js
+++ b/src/renderer/scripts/handlers/keyboard-handler.js
@@ -55,6 +55,9 @@ export class KeyboardHandler {
             // Block shortcuts
             { key: 'q', ctrl: true, shift: true, action: 'changeType:blockquote' },
             { key: 'c', ctrl: true, shift: true, action: 'changeType:code-block' },
+
+            // Search
+            { key: 'f', ctrl: true, action: 'search:open' },
         ];
     }
 
@@ -147,6 +150,9 @@ export class KeyboardHandler {
                 break;
             case 'changeType':
                 this.editor.changeElementType(actionValue);
+                break;
+            case 'search':
+                document.dispatchEvent(new CustomEvent('search:open'));
                 break;
             default:
                 console.warn(`Unknown action type: ${actionType}`);

--- a/src/renderer/scripts/search/search-bar.js
+++ b/src/renderer/scripts/search/search-bar.js
@@ -1,0 +1,681 @@
+/**
+ * @fileoverview Search bar for finding text in the editor.
+ *
+ * Supports plain text and regex matching, case-sensitive and
+ * case-insensitive modes.  Searches against `syntaxTree.toMarkdown()`
+ * in source view and `syntaxTree.toBareText()` in focused view, then
+ * maps match offsets back to individual syntax-tree nodes for DOM
+ * highlighting.
+ */
+
+/**
+ * @typedef {Object} SearchMatch
+ * @property {number} docStart  - Start offset in the full document string
+ * @property {number} docEnd    - End offset in the full document string
+ */
+
+/**
+ * @typedef {Object} NodeSegment
+ * @property {string} nodeId
+ * @property {number} startOffset  - Start within the node's text
+ * @property {number} endOffset    - End within the node's text
+ */
+
+/**
+ * @typedef {Object} OffsetMapEntry
+ * @property {string} nodeId
+ * @property {number} docStart     - Where this node's text begins in the flat document
+ * @property {number} docEnd       - Where this node's text ends in the flat document
+ * @property {string} text         - The node's text (markdown or bare)
+ */
+
+export class SearchBar {
+    /**
+     * @param {import('../editor/editor.js').Editor} editor
+     */
+    constructor(editor) {
+        /** @type {import('../editor/editor.js').Editor} */
+        this.editor = editor;
+
+        /** @type {HTMLElement|null} */
+        this.container = null;
+
+        /** @type {HTMLInputElement|null} */
+        this._input = null;
+
+        /** @type {HTMLElement|null} */
+        this._matchCount = null;
+
+        /** @type {boolean} */
+        this._useRegex = false;
+
+        /** @type {boolean} */
+        this._caseSensitive = false;
+
+        /** @type {boolean} */
+        this._visible = false;
+
+        /** @type {SearchMatch[]} */
+        this._matches = [];
+
+        /** @type {number} */
+        this._currentIndex = -1;
+
+        /** @type {OffsetMapEntry[]} */
+        this._offsetMap = [];
+
+        /** @type {string} */
+        this._documentText = '';
+
+        /**
+         * Bound handler for render-complete events so we can remove it.
+         * @type {(() => void)|null}
+         */
+        this._renderCompleteHandler = null;
+    }
+
+    /**
+     * Builds the DOM for the search bar and inserts it into the page.
+     * Called once during app initialisation.
+     */
+    initialize() {
+        this.container = document.createElement('div');
+        this.container.className = 'search-bar';
+        this.container.setAttribute('role', 'search');
+        this.container.setAttribute('aria-label', 'Find in document');
+        // Prevent the editor from losing focus metrics when clicking
+        // inside the search bar — but we do want the input to be
+        // focusable, so we only guard non-input clicks.
+        // Also initiate drag when the mousedown is not on an interactive
+        // element (input or button).
+        this.container.addEventListener('mousedown', (e) => {
+            const tag = /** @type {HTMLElement} */ (e.target).tagName;
+            if (tag !== 'INPUT' && tag !== 'BUTTON') {
+                e.preventDefault();
+                this._startDrag(e);
+            } else if (tag === 'BUTTON') {
+                e.preventDefault();
+            }
+        });
+
+        this.container.innerHTML = `
+            <div class="search-bar-inner">
+                <input
+                    type="text"
+                    class="search-input"
+                    placeholder="Find…"
+                    aria-label="Search text"
+                    spellcheck="false"
+                    autocomplete="off"
+                />
+                <button class="search-toggle" data-action="regex" title="Use regular expression" aria-pressed="false">.*</button>
+                <button class="search-toggle" data-action="case" title="Match case" aria-pressed="false">Aa</button>
+                <span class="search-match-count" aria-live="polite"></span>
+                <button class="search-nav-btn" data-action="prev" title="Previous match (Shift+Enter)" aria-label="Previous match">&#x25B2;</button>
+                <button class="search-nav-btn" data-action="next" title="Next match (Enter)" aria-label="Next match">&#x25BC;</button>
+                <button class="search-close-btn" title="Close (Escape)" aria-label="Close search">&times;</button>
+            </div>
+        `;
+
+        this._input = /** @type {HTMLInputElement} */ (
+            this.container.querySelector('.search-input')
+        );
+        this._matchCount = /** @type {HTMLElement} */ (
+            this.container.querySelector('.search-match-count')
+        );
+
+        // Wire up events
+        this._input.addEventListener('input', () => this._onSearchChanged());
+        this._input.addEventListener('keydown', (e) => this._onInputKeyDown(e));
+
+        // Toggle buttons
+        for (const btn of this.container.querySelectorAll('.search-toggle')) {
+            btn.addEventListener('click', () => {
+                const action = /** @type {HTMLElement} */ (btn).dataset.action;
+                if (action === 'regex') {
+                    this._useRegex = !this._useRegex;
+                    btn.setAttribute('aria-pressed', String(this._useRegex));
+                    btn.classList.toggle('active', this._useRegex);
+                } else if (action === 'case') {
+                    this._caseSensitive = !this._caseSensitive;
+                    btn.setAttribute('aria-pressed', String(this._caseSensitive));
+                    btn.classList.toggle('active', this._caseSensitive);
+                }
+                this._onSearchChanged();
+            });
+        }
+
+        // Navigation buttons
+        for (const btn of this.container.querySelectorAll('.search-nav-btn')) {
+            btn.addEventListener('click', () => {
+                const action = /** @type {HTMLElement} */ (btn).dataset.action;
+                if (action === 'prev') this.previous();
+                if (action === 'next') this.next();
+            });
+        }
+
+        // Close button
+        const closeBtn = /** @type {HTMLElement} */ (
+            this.container.querySelector('.search-close-btn')
+        );
+        closeBtn.addEventListener('click', () => this.close());
+
+        // Insert into the DOM as a floating panel inside #app.
+        const app = document.getElementById('app');
+        if (app) {
+            app.appendChild(this.container);
+        }
+
+        // Start hidden
+        this.container.style.display = 'none';
+
+        // Listen for renders so we can re-apply highlights
+        this._renderCompleteHandler = () => this._applyHighlights();
+        document.addEventListener('editor:renderComplete', this._renderCompleteHandler);
+    }
+
+    /**
+     * Opens the search bar, focusing the input.  If already open,
+     * selects the current search text for quick replacement.
+     */
+    open() {
+        if (!this.container || !this._input) return;
+        this._visible = true;
+        this.container.style.display = '';
+        // Reset position to default top-right corner.
+        this.container.style.top = '';
+        this.container.style.right = '';
+        this.container.style.left = '';
+        this._input.focus();
+        this._input.select();
+        // Re-run the search in case the view mode changed since
+        // the bar was last open.
+        this._onSearchChanged();
+    }
+
+    /**
+     * Closes the search bar and clears all highlights.
+     */
+    close() {
+        if (!this.container) return;
+        this._visible = false;
+        this.container.style.display = 'none';
+        this._clearHighlights();
+        this._matches = [];
+        this._currentIndex = -1;
+        this._updateMatchCount();
+        // Return focus to the editor
+        this.editor.container.focus();
+    }
+
+    /** @returns {boolean} Whether the search bar is currently visible. */
+    get isOpen() {
+        return this._visible;
+    }
+
+    /** Navigates to the next match. */
+    next() {
+        if (this._matches.length === 0) return;
+        this._currentIndex = (this._currentIndex + 1) % this._matches.length;
+        this._updateMatchCount();
+        this._applyHighlights();
+        this._scrollToCurrentMatch();
+    }
+
+    /** Navigates to the previous match. */
+    previous() {
+        if (this._matches.length === 0) return;
+        this._currentIndex = (this._currentIndex - 1 + this._matches.length) % this._matches.length;
+        this._updateMatchCount();
+        this._applyHighlights();
+        this._scrollToCurrentMatch();
+    }
+
+    /** Cleans up event listeners. */
+    destroy() {
+        if (this._renderCompleteHandler) {
+            document.removeEventListener('editor:renderComplete', this._renderCompleteHandler);
+            this._renderCompleteHandler = null;
+        }
+        this.container?.remove();
+    }
+
+    // ─── Drag handling ──────────────────────────────────────────
+
+    /**
+     * Begins dragging the search panel.
+     * @param {MouseEvent} e
+     */
+    _startDrag(e) {
+        if (!this.container) return;
+        const rect = this.container.getBoundingClientRect();
+        const offsetX = e.clientX - rect.left;
+        const offsetY = e.clientY - rect.top;
+
+        /** @param {MouseEvent} moveEvent */
+        const onMove = (moveEvent) => {
+            if (!this.container) return;
+            const x = moveEvent.clientX - offsetX;
+            const y = moveEvent.clientY - offsetY;
+            this.container.style.left = `${x}px`;
+            this.container.style.top = `${y}px`;
+            this.container.style.right = 'auto';
+        };
+
+        const onUp = () => {
+            document.removeEventListener('mousemove', onMove);
+            document.removeEventListener('mouseup', onUp);
+        };
+
+        document.addEventListener('mousemove', onMove);
+        document.addEventListener('mouseup', onUp);
+    }
+
+    // ─── Private ────────────────────────────────────────────
+
+    /**
+     * Called whenever the search input or toggles change.
+     * Rebuilds the offset map, runs the search, highlights results.
+     */
+    _onSearchChanged() {
+        const query = this._input?.value ?? '';
+        this._buildOffsetMap();
+        this._runSearch(query);
+        this._currentIndex = this._findClosestMatchIndex();
+        this._updateMatchCount();
+        this._applyHighlights();
+        if (this._matches.length > 0) {
+            this._scrollToCurrentMatch();
+        }
+    }
+
+    /**
+     * Returns the index of the first match at or after the current
+     * cursor position, so the user sees the closest hit rather than
+     * always jumping to the top of the document.  Falls back to 0 if
+     * the cursor is past all matches.
+     *
+     * @returns {number} Index into `this._matches`, or -1 if empty.
+     */
+    _findClosestMatchIndex() {
+        if (this._matches.length === 0) return -1;
+
+        const cursor = this.editor.treeCursor;
+        if (!cursor) return 0;
+
+        // Convert the cursor's (nodeId, offset) to a document-level
+        // offset using the offset map we already built.
+        let cursorDocOffset = 0;
+        for (const entry of this._offsetMap) {
+            if (entry.nodeId === cursor.nodeId) {
+                cursorDocOffset = entry.docStart + cursor.offset;
+                break;
+            }
+        }
+
+        // Find the first match whose start is >= the cursor position.
+        for (let i = 0; i < this._matches.length; i++) {
+            if (this._matches[i].docStart >= cursorDocOffset) return i;
+        }
+
+        // Cursor is past all matches — wrap to the first one.
+        return 0;
+    }
+
+    /**
+     * Handles keydown inside the search input.
+     * @param {KeyboardEvent} e
+     */
+    _onInputKeyDown(e) {
+        if (e.key === 'Escape') {
+            e.preventDefault();
+            this.close();
+        } else if (e.key === 'Enter' && e.shiftKey) {
+            e.preventDefault();
+            this.previous();
+        } else if (e.key === 'Enter') {
+            e.preventDefault();
+            this.next();
+        }
+    }
+
+    /**
+     * Builds the flat document text and an offset map that lets us
+     * translate document-level offsets to per-node offsets.
+     */
+    _buildOffsetMap() {
+        const tree = this.editor.syntaxTree;
+        if (!tree) {
+            this._documentText = '';
+            this._offsetMap = [];
+            return;
+        }
+
+        const isSource = this.editor.viewMode === 'source';
+        /** @type {OffsetMapEntry[]} */
+        const map = [];
+        let pos = 0;
+
+        /**
+         * Recursively walks nodes and appends their text to the map.
+         * @param {import('../../scripts/parser/syntax-tree.js').SyntaxNode[]} nodes
+         * @param {boolean} isFirst - Whether we need to prepend a separator
+         */
+        const walk = (nodes, isFirst) => {
+            let first = isFirst;
+            for (const node of nodes) {
+                // html-block containers are virtual — their text is produced
+                // by their children.  In source mode the opening/closing tag
+                // lines are part of toMarkdown(), so we handle them as a unit.
+                if (node.type === 'html-block' && node.children.length > 0) {
+                    if (isSource) {
+                        // Source mode: the whole block is one markdown chunk.
+                        const text = node.toMarkdown();
+                        if (!first) {
+                            pos += 2; // \n\n separator
+                        }
+                        map.push({
+                            nodeId: node.id,
+                            docStart: pos,
+                            docEnd: pos + text.length,
+                            text,
+                        });
+                        pos += text.length;
+                        first = false;
+                    } else {
+                        // Focused mode: only bare-text single-child containers
+                        // collapse into one entry; multi-child containers
+                        // flatten their children.
+                        if (
+                            node.children.length === 1 &&
+                            node.children[0].attributes.bareText &&
+                            node.children[0].type === 'paragraph'
+                        ) {
+                            const text = node.toBareText();
+                            if (!first) pos += 2;
+                            map.push({
+                                nodeId: node.children[0].id,
+                                docStart: pos,
+                                docEnd: pos + text.length,
+                                text,
+                            });
+                            pos += text.length;
+                            first = false;
+                        } else {
+                            walk(node.children, first);
+                            first = false;
+                        }
+                    }
+                    continue;
+                }
+
+                const text = isSource ? node.toMarkdown() : node.toBareText();
+                // Skip nodes that produce no text (images, hr in focused)
+                if (text === '') continue;
+
+                if (!first) {
+                    pos += 2; // \n\n separator
+                }
+                map.push({ nodeId: node.id, docStart: pos, docEnd: pos + text.length, text });
+                pos += text.length;
+                first = false;
+            }
+        };
+
+        walk(tree.children, true);
+
+        // Reconstruct the flat document string from the map so it is
+        // guaranteed to align with the offsets.
+        let doc = '';
+        for (let i = 0; i < map.length; i++) {
+            if (i > 0) {
+                // Fill the gap between previous entry end and this entry start
+                const gap = map[i].docStart - map[i - 1].docEnd;
+                doc += '\n\n'.substring(0, gap);
+            }
+            doc += map[i].text;
+        }
+        this._documentText = doc;
+        this._offsetMap = map;
+    }
+
+    /**
+     * Runs the search query against the flat document text and
+     * populates `this._matches`.
+     *
+     * @param {string} query
+     */
+    _runSearch(query) {
+        this._matches = [];
+        if (!query || !this._documentText) return;
+
+        // Require at least 2 characters for plain-text searches to
+        // avoid an overwhelming number of single-letter hits.
+        if (!this._useRegex && query.length < 2) return;
+
+        // In focused view, plain-text (non-regex) searches are confined
+        // to individual elements so matches don't span across block
+        // boundaries — this feels more natural in WYSIWYG mode.
+        const perNode = !this._useRegex && this.editor.viewMode === 'focused';
+
+        if (perNode) {
+            const flags = this._caseSensitive ? 'g' : 'gi';
+            const re = new RegExp(SearchBar._escapeRegex(query), flags);
+            for (const entry of this._offsetMap) {
+                let m;
+                // biome-ignore lint/suspicious/noAssignInExpressions: standard regex exec loop
+                while ((m = re.exec(entry.text)) !== null) {
+                    this._matches.push({
+                        docStart: entry.docStart + m.index,
+                        docEnd: entry.docStart + m.index + m[0].length,
+                    });
+                }
+                re.lastIndex = 0;
+            }
+            return;
+        }
+
+        try {
+            const flags = this._caseSensitive ? 'g' : 'gi';
+            const pattern = this._useRegex ? query : SearchBar._escapeRegex(query);
+            const re = new RegExp(pattern, flags);
+
+            let m;
+            // biome-ignore lint/suspicious/noAssignInExpressions: standard regex exec loop
+            while ((m = re.exec(this._documentText)) !== null) {
+                // Guard against zero-length matches causing an infinite loop.
+                if (m[0].length === 0) {
+                    re.lastIndex++;
+                    continue;
+                }
+                this._matches.push({ docStart: m.index, docEnd: m.index + m[0].length });
+            }
+        } catch {
+            // Invalid regex — treat as no matches.
+        }
+    }
+
+    /**
+     * Maps a single document-level match to one or more per-node
+     * segments for highlighting.
+     *
+     * @param {SearchMatch} match
+     * @returns {NodeSegment[]}
+     */
+    _matchToSegments(match) {
+        /** @type {NodeSegment[]} */
+        const segments = [];
+
+        for (const entry of this._offsetMap) {
+            // Does this match overlap with this entry?
+            if (match.docEnd <= entry.docStart || match.docStart >= entry.docEnd) {
+                continue;
+            }
+            const startInNode = Math.max(0, match.docStart - entry.docStart);
+            const endInNode = Math.min(entry.text.length, match.docEnd - entry.docStart);
+            segments.push({ nodeId: entry.nodeId, startOffset: startInNode, endOffset: endInNode });
+        }
+
+        return segments;
+    }
+
+    /**
+     * Clears all `<mark>` highlight elements from the editor DOM.
+     */
+    _clearHighlights() {
+        const marks = this.editor.container.querySelectorAll('mark.search-highlight');
+        for (const mark of marks) {
+            const parent = mark.parentNode;
+            if (!parent) continue;
+            // Replace the <mark> with its text content.
+            const text = document.createTextNode(mark.textContent ?? '');
+            parent.replaceChild(text, mark);
+            // Merge adjacent text nodes.
+            parent.normalize();
+        }
+    }
+
+    /**
+     * Applies `<mark>` highlights for all current matches into the
+     * editor DOM.  Called after every search change and after renders.
+     */
+    _applyHighlights() {
+        this._clearHighlights();
+        if (!this._visible || this._matches.length === 0) return;
+
+        for (let i = 0; i < this._matches.length; i++) {
+            const segments = this._matchToSegments(this._matches[i]);
+            const isActive = i === this._currentIndex;
+
+            for (const seg of segments) {
+                this._highlightSegment(seg, isActive);
+            }
+        }
+    }
+
+    /**
+     * Highlights a single per-node segment by wrapping the matching
+     * text range in a `<mark>` element.
+     *
+     * We walk the text nodes inside the `[data-node-id]` element,
+     * accumulate offsets, and split/wrap the target range.
+     *
+     * In **source mode** the searchable text is the full markdown line
+     * including the prefix (e.g. `## Heading`).  However the DOM
+     * separates the prefix into `span.md-syntax` and the content into
+     * `span.md-content` (or a bare text node for paragraphs).  We walk
+     * *all* text nodes inside the `[data-node-id]` element in document
+     * order, which naturally visits prefix text first and content text
+     * second — the accumulated offset therefore aligns with the
+     * `toMarkdown()` output.
+     *
+     * In **focused mode** the searchable text comes from `toBareText()`
+     * which strips formatting delimiters.  The DOM contains text nodes
+     * interleaved with inline formatting elements (`<strong>`, `<em>`,
+     * etc.) and empty cursor-landing-pad text nodes.  We walk all text
+     * nodes, skipping empty ones, so the accumulated visible text
+     * aligns with the `toBareText()` output.
+     *
+     * **Code blocks** are a special case: in source mode the
+     * `toMarkdown()` output includes the fence lines
+     * (` ```lang ` / ` ``` `) and the code content, separated by `\n`.
+     * The DOM renders these as separate child `<div>` elements
+     * (`div.md-code-fence` + `div.md-code-content` + `div.md-code-fence`)
+     * whose text nodes we walk in order.
+     *
+     * @param {NodeSegment} seg
+     * @param {boolean} isActive
+     */
+    _highlightSegment(seg, isActive) {
+        const el = this.editor.container.querySelector(`[data-node-id="${seg.nodeId}"]`);
+        if (!el) return;
+
+        const isFocused = this.editor.viewMode === 'focused';
+
+        // Collect text nodes in document order via TreeWalker.
+        const walker = document.createTreeWalker(el, NodeFilter.SHOW_TEXT);
+        /** @type {{ node: Text, start: number, end: number }[]} */
+        const textRuns = [];
+        let offset = 0;
+        /** @type {Text|null} */
+        let textNode;
+        // biome-ignore lint/suspicious/noAssignInExpressions: standard TreeWalker loop
+        while ((textNode = /** @type {Text|null} */ (walker.nextNode()))) {
+            const len = textNode.textContent?.length ?? 0;
+            // In focused mode, skip empty landing-pad text nodes.
+            if (isFocused && len === 0) continue;
+            textRuns.push({ node: textNode, start: offset, end: offset + len });
+            offset += len;
+        }
+
+        // Now wrap the portion [seg.startOffset, seg.endOffset) in <mark>.
+        for (const run of textRuns) {
+            // Does this text run overlap with the segment?
+            if (seg.endOffset <= run.start || seg.startOffset >= run.end) continue;
+
+            const wrapStart = Math.max(0, seg.startOffset - run.start);
+            const wrapEnd = Math.min(run.node.textContent?.length ?? 0, seg.endOffset - run.start);
+
+            const mark = document.createElement('mark');
+            mark.className = isActive
+                ? 'search-highlight search-highlight--active'
+                : 'search-highlight';
+
+            // Split the text node and wrap the middle part.
+            const before = run.node.textContent?.substring(0, wrapStart) ?? '';
+            const matched = run.node.textContent?.substring(wrapStart, wrapEnd) ?? '';
+            const after = run.node.textContent?.substring(wrapEnd) ?? '';
+
+            const parent = run.node.parentNode;
+            if (!parent) continue;
+
+            mark.textContent = matched;
+
+            // Build replacement nodes.
+            const frag = document.createDocumentFragment();
+            if (before) frag.appendChild(document.createTextNode(before));
+            frag.appendChild(mark);
+            if (after) frag.appendChild(document.createTextNode(after));
+
+            parent.replaceChild(frag, run.node);
+
+            // The remaining runs in this node may have shifted — but
+            // since we process each match independently and clear
+            // highlights before each pass, this is safe.
+            break; // Each run is processed once per segment.
+        }
+    }
+
+    /**
+     * Scrolls the current active match into view.
+     */
+    _scrollToCurrentMatch() {
+        const active = this.editor.container.querySelector('mark.search-highlight--active');
+        if (active) {
+            active.scrollIntoView({ block: 'center', behavior: 'instant' });
+        }
+    }
+
+    /** Updates the "N of M" match count display. */
+    _updateMatchCount() {
+        if (!this._matchCount) return;
+        if (this._matches.length === 0) {
+            const query = this._input?.value ?? '';
+            // Don't show "No results" when the query is too short to
+            // trigger a search (< 2 chars in plain-text mode).
+            const tooShort = !this._useRegex && query.length < 2;
+            this._matchCount.textContent = query && !tooShort ? 'No results' : '';
+        } else {
+            this._matchCount.textContent = `${this._currentIndex + 1} of ${this._matches.length}`;
+        }
+    }
+
+    /**
+     * Escapes a string for use in a RegExp.
+     * @param {string} str
+     * @returns {string}
+     */
+    static _escapeRegex(str) {
+        return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    }
+}

--- a/src/renderer/styles/search.css
+++ b/src/renderer/styles/search.css
@@ -1,0 +1,145 @@
+/* ── Search bar (floating modal) ───────────────────────────────────── */
+
+.search-bar {
+    position: absolute;
+    top: 48px;
+    right: 16px;
+    background-color: var(--color-bg-secondary);
+    border: 1px solid var(--color-border);
+    border-radius: 6px;
+    padding: var(--spacing-xs) var(--spacing-md);
+    z-index: 100;
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.15);
+    cursor: grab;
+    user-select: none;
+}
+
+.search-bar:active {
+    cursor: grabbing;
+}
+
+.search-bar-inner {
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-xs);
+}
+
+/* ── Input ────────────────────────────────────────────────────────── */
+
+.search-input {
+    flex: 1 1 auto;
+    min-width: 120px;
+    padding: var(--spacing-xs) var(--spacing-sm);
+    border: 1px solid var(--color-border);
+    border-radius: 4px;
+    font-family: var(--font-family);
+    font-size: 0.875rem;
+    color: var(--color-text);
+    background-color: var(--color-bg);
+    outline: none;
+}
+
+.search-input:focus {
+    border-color: var(--color-primary);
+    box-shadow: 0 0 0 2px rgba(13, 110, 253, 0.15);
+}
+
+/* ── Toggle buttons (regex, case) ─────────────────────────────────── */
+
+.search-toggle {
+    flex-shrink: 0;
+    padding: var(--spacing-xs) var(--spacing-sm);
+    border: 1px solid var(--color-border);
+    border-radius: 4px;
+    background-color: var(--color-bg);
+    font-family: var(--font-family-mono);
+    font-size: 0.8125rem;
+    color: var(--color-text-secondary);
+    cursor: pointer;
+    line-height: 1;
+    user-select: none;
+}
+
+.search-toggle:hover {
+    background-color: var(--color-bg-secondary);
+}
+
+.search-toggle.active {
+    background-color: var(--color-primary);
+    color: #ffffff;
+    border-color: var(--color-primary);
+}
+
+/* ── Match count ──────────────────────────────────────────────────── */
+
+.search-match-count {
+    flex-shrink: 0;
+    font-size: 0.8125rem;
+    color: var(--color-text-secondary);
+    white-space: nowrap;
+    min-width: 64px;
+    text-align: center;
+}
+
+/* ── Navigation buttons (prev / next) ─────────────────────────────── */
+
+.search-nav-btn {
+    flex-shrink: 0;
+    width: 28px;
+    height: 28px;
+    padding: 0;
+    border: 1px solid var(--color-border);
+    border-radius: 4px;
+    background-color: var(--color-bg);
+    color: var(--color-text-secondary);
+    font-size: 0.75rem;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    user-select: none;
+}
+
+.search-nav-btn:hover {
+    background-color: var(--color-bg-secondary);
+    color: var(--color-text);
+}
+
+/* ── Close button ─────────────────────────────────────────────────── */
+
+.search-close-btn {
+    flex-shrink: 0;
+    width: 28px;
+    height: 28px;
+    padding: 0;
+    border: none;
+    border-radius: 4px;
+    background-color: transparent;
+    color: var(--color-text-secondary);
+    font-size: 1.125rem;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    user-select: none;
+    line-height: 1;
+}
+
+.search-close-btn:hover {
+    background-color: var(--color-bg-secondary);
+    color: var(--color-text);
+}
+
+/* ── Highlights ───────────────────────────────────────────────────── */
+
+mark.search-highlight {
+    background-color: rgba(255, 213, 0, 0.4);
+    color: inherit;
+    border-radius: 2px;
+    padding: 0;
+}
+
+mark.search-highlight--active {
+    background-color: rgba(255, 150, 0, 0.6);
+    outline: 2px solid rgba(255, 150, 0, 0.8);
+}

--- a/test/integration/search.spec.js
+++ b/test/integration/search.spec.js
@@ -1,0 +1,427 @@
+/**
+ * @fileoverview Integration tests for the search bar feature.
+ *
+ * Verifies that Ctrl+F opens the search bar, plain text and regex
+ * search work in both source and focused view, match highlighting
+ * is applied, navigation between matches works, and the bar closes
+ * cleanly on Escape.
+ */
+
+import { expect, test } from '@playwright/test';
+import { MOD, launchApp, loadContent, setFocusedView, setSourceView } from './test-utils.js';
+
+/** @type {import('@playwright/test').ElectronApplication} */
+let electronApp;
+
+/** @type {import('@playwright/test').Page} */
+let page;
+
+const FIXTURE = [
+    '# Heading with cake',
+    '',
+    'A paragraph about cake and pie.',
+    '',
+    '## Another heading',
+    '',
+    'Some **bold text** and *italic words* here.',
+    '',
+    '- List item one',
+    '',
+    '- List item two',
+    '',
+    '```js',
+    'const cake = true;',
+    '```',
+].join('\n');
+
+test.beforeAll(async () => {
+    ({ electronApp, page } = await launchApp());
+});
+
+test.afterAll(async () => {
+    await electronApp.close();
+});
+
+// ─── Opening and closing ────────────────────────────────────────────
+
+test('Ctrl+F opens the search bar', async () => {
+    await loadContent(page, FIXTURE);
+    // Search bar should be hidden initially.
+    const bar = page.locator('.search-bar');
+    await expect(bar).toBeHidden();
+
+    // Open with Ctrl+F.
+    await page.keyboard.press(`${MOD}+f`);
+    await expect(bar).toBeVisible();
+
+    // The input should be focused.
+    const input = page.locator('.search-input');
+    await expect(input).toBeFocused();
+});
+
+test('Escape closes the search bar', async () => {
+    await loadContent(page, FIXTURE);
+    await page.keyboard.press(`${MOD}+f`);
+    await expect(page.locator('.search-bar')).toBeVisible();
+
+    await page.keyboard.press('Escape');
+    await expect(page.locator('.search-bar')).toBeHidden();
+});
+
+test('Ctrl+F while open selects the search text', async () => {
+    await loadContent(page, FIXTURE);
+    await page.keyboard.press(`${MOD}+f`);
+    const input = page.locator('.search-input');
+    await input.fill('hello');
+
+    // Press Ctrl+F again — text should be selected.
+    await page.keyboard.press(`${MOD}+f`);
+    await expect(input).toBeFocused();
+    const selected = await input.evaluate((el) => {
+        const inp = /** @type {HTMLInputElement} */ (el);
+        return (inp.selectionEnd ?? 0) - (inp.selectionStart ?? 0);
+    });
+    expect(selected).toBe(5);
+});
+
+// ─── Plain text search in source view ───────────────────────────────
+
+test('plain text search highlights matches in source view', async () => {
+    await loadContent(page, FIXTURE);
+    await setSourceView(page);
+    await page.keyboard.press(`${MOD}+f`);
+    const input = page.locator('.search-input');
+    await input.fill('cake');
+
+    // Should find matches.
+    const matchCount = page.locator('.search-match-count');
+    await expect(matchCount).not.toHaveText('No results');
+
+    // There should be <mark> elements in the editor.
+    const marks = page.locator('#editor mark.search-highlight');
+    const count = await marks.count();
+    expect(count).toBeGreaterThanOrEqual(2); // heading + paragraph + code
+
+    // One should be the active match.
+    const active = page.locator('#editor mark.search-highlight--active');
+    await expect(active).toHaveCount(1);
+
+    await page.keyboard.press('Escape');
+});
+
+test('plain text search is case insensitive by default', async () => {
+    await loadContent(page, FIXTURE);
+    await setSourceView(page);
+    await page.keyboard.press(`${MOD}+f`);
+    const input = page.locator('.search-input');
+    await input.fill('Cake');
+
+    // Should still match lowercase 'cake' in paragraph and code.
+    const matchCount = page.locator('.search-match-count');
+    await expect(matchCount).not.toHaveText('No results');
+
+    const marks = page.locator('#editor mark.search-highlight');
+    const count = await marks.count();
+    expect(count).toBeGreaterThanOrEqual(2);
+
+    await page.keyboard.press('Escape');
+});
+
+test('case sensitive toggle restricts matches', async () => {
+    await loadContent(page, FIXTURE);
+    await setSourceView(page);
+    await page.keyboard.press(`${MOD}+f`);
+    const input = page.locator('.search-input');
+    await input.fill('Cake');
+
+    // Click case-sensitive toggle.
+    await page.locator('.search-toggle[data-action="case"]').click();
+
+    // 'Cake' (capital C) should not match 'cake' (lowercase).
+    const matchCount = page.locator('.search-match-count');
+    await expect(matchCount).toHaveText('No results');
+
+    // Toggle off and close.
+    await page.locator('.search-toggle[data-action="case"]').click();
+    await page.keyboard.press('Escape');
+});
+
+// ─── Regex search ───────────────────────────────────────────────────
+
+test('regex search finds pattern matches', async () => {
+    await loadContent(page, FIXTURE);
+    await setSourceView(page);
+    await page.keyboard.press(`${MOD}+f`);
+
+    // Enable regex mode.
+    await page.locator('.search-toggle[data-action="regex"]').click();
+
+    const input = page.locator('.search-input');
+    await input.fill('cake|pie');
+
+    // Should find multiple matches.
+    const marks = page.locator('#editor mark.search-highlight');
+    const count = await marks.count();
+    expect(count).toBeGreaterThanOrEqual(3); // 'cake' in heading + paragraph + code, 'pie' in paragraph
+
+    // Toggle off and close.
+    await page.locator('.search-toggle[data-action="regex"]').click();
+    await page.keyboard.press('Escape');
+});
+
+test('invalid regex shows no results instead of error', async () => {
+    await loadContent(page, FIXTURE);
+    await setSourceView(page);
+    await page.keyboard.press(`${MOD}+f`);
+
+    await page.locator('.search-toggle[data-action="regex"]').click();
+    const input = page.locator('.search-input');
+    await input.fill('[invalid');
+
+    const matchCount = page.locator('.search-match-count');
+    await expect(matchCount).toHaveText('No results');
+
+    await page.locator('.search-toggle[data-action="regex"]').click();
+    await page.keyboard.press('Escape');
+});
+
+// ─── Navigation ─────────────────────────────────────────────────────
+
+test('Enter navigates to next match', async () => {
+    await loadContent(page, FIXTURE);
+    await setSourceView(page);
+    await page.keyboard.press(`${MOD}+f`);
+    const input = page.locator('.search-input');
+    await input.fill('cake');
+
+    const matchCount = page.locator('.search-match-count');
+    await expect(matchCount).toContainText('1 of');
+
+    // Press Enter → next match.
+    await page.keyboard.press('Enter');
+    await expect(matchCount).toContainText('2 of');
+
+    await page.keyboard.press('Escape');
+});
+
+test('Shift+Enter navigates to previous match', async () => {
+    await loadContent(page, FIXTURE);
+    await setSourceView(page);
+    await page.keyboard.press(`${MOD}+f`);
+    const input = page.locator('.search-input');
+    await input.fill('cake');
+
+    const matchCount = page.locator('.search-match-count');
+    await expect(matchCount).toContainText('1 of');
+
+    // Go forward then back.
+    await page.keyboard.press('Enter');
+    await expect(matchCount).toContainText('2 of');
+    await page.keyboard.press('Shift+Enter');
+    await expect(matchCount).toContainText('1 of');
+
+    await page.keyboard.press('Escape');
+});
+
+test('next/prev buttons navigate matches', async () => {
+    await loadContent(page, FIXTURE);
+    await setSourceView(page);
+    await page.keyboard.press(`${MOD}+f`);
+    const input = page.locator('.search-input');
+    await input.fill('cake');
+
+    const matchCount = page.locator('.search-match-count');
+    await expect(matchCount).toContainText('1 of');
+
+    await page.locator('.search-nav-btn[data-action="next"]').click();
+    await expect(matchCount).toContainText('2 of');
+
+    await page.locator('.search-nav-btn[data-action="prev"]').click();
+    await expect(matchCount).toContainText('1 of');
+
+    await page.keyboard.press('Escape');
+});
+
+// ─── Focused view ───────────────────────────────────────────────────
+
+test('search works in focused view (bare text)', async () => {
+    await loadContent(page, FIXTURE);
+    await setFocusedView(page);
+    await page.keyboard.press(`${MOD}+f`);
+    const input = page.locator('.search-input');
+    await input.fill('cake');
+
+    // In focused view, **bold** delimiters are stripped, so searching
+    // for 'cake' should still find the heading and paragraph matches.
+    const marks = page.locator('#editor mark.search-highlight');
+    const count = await marks.count();
+    expect(count).toBeGreaterThanOrEqual(2);
+
+    await page.keyboard.press('Escape');
+});
+
+test('focused view search does not match markdown syntax', async () => {
+    await loadContent(page, FIXTURE);
+    await setFocusedView(page);
+    await page.keyboard.press(`${MOD}+f`);
+    const input = page.locator('.search-input');
+    // Search for markdown heading prefix — should not match in focused view
+    // because toBareText strips it.
+    await input.fill('##');
+
+    const matchCount = page.locator('.search-match-count');
+    await expect(matchCount).toHaveText('No results');
+
+    await page.keyboard.press('Escape');
+});
+
+test('source view search matches markdown syntax', async () => {
+    await loadContent(page, FIXTURE);
+    await setSourceView(page);
+    await page.keyboard.press(`${MOD}+f`);
+    const input = page.locator('.search-input');
+    await input.fill('##');
+
+    // Source mode should find '##' in heading lines.
+    const matchCount = page.locator('.search-match-count');
+    await expect(matchCount).not.toHaveText('No results');
+
+    await page.keyboard.press('Escape');
+});
+
+// ─── Highlights cleared on close ────────────────────────────────────
+
+test('highlights are removed when search bar closes', async () => {
+    await loadContent(page, FIXTURE);
+    await setSourceView(page);
+    await page.keyboard.press(`${MOD}+f`);
+    const input = page.locator('.search-input');
+    await input.fill('cake');
+
+    // Marks should exist.
+    let marks = page.locator('#editor mark.search-highlight');
+    expect(await marks.count()).toBeGreaterThan(0);
+
+    // Close the search bar.
+    await page.keyboard.press('Escape');
+
+    // Marks should be gone.
+    marks = page.locator('#editor mark.search-highlight');
+    await expect(marks).toHaveCount(0);
+});
+
+// ─── Close button ───────────────────────────────────────────────────
+
+test('close button closes the search bar', async () => {
+    await loadContent(page, FIXTURE);
+    await page.keyboard.press(`${MOD}+f`);
+    await expect(page.locator('.search-bar')).toBeVisible();
+
+    await page.locator('.search-close-btn').click();
+    await expect(page.locator('.search-bar')).toBeHidden();
+});
+
+// ─── No results ─────────────────────────────────────────────────────
+
+test('shows "No results" for unmatched query', async () => {
+    await loadContent(page, FIXTURE);
+    await setSourceView(page);
+    await page.keyboard.press(`${MOD}+f`);
+    const input = page.locator('.search-input');
+    await input.fill('xyznonexistent');
+
+    const matchCount = page.locator('.search-match-count');
+    await expect(matchCount).toHaveText('No results');
+
+    await page.keyboard.press('Escape');
+});
+
+// ─── Cross-node regex match ─────────────────────────────────────────
+
+test('regex can match across element boundaries', async () => {
+    await loadContent(page, FIXTURE);
+    await setSourceView(page);
+    await page.keyboard.press(`${MOD}+f`);
+
+    await page.locator('.search-toggle[data-action="regex"]').click();
+    const input = page.locator('.search-input');
+    // Match across the heading into the paragraph (separated by \n\n).
+    await input.fill('cake\\n\\nA paragraph');
+
+    const matchCount = page.locator('.search-match-count');
+    await expect(matchCount).toContainText('1 of 1');
+
+    // Should produce highlight marks in both the heading and paragraph.
+    const marks = page.locator('#editor mark.search-highlight');
+    expect(await marks.count()).toBe(2);
+
+    await page.locator('.search-toggle[data-action="regex"]').click();
+    await page.keyboard.press('Escape');
+});
+
+// ─── Minimum query length ───────────────────────────────────────────
+
+test('plain text search requires at least 2 characters', async () => {
+    await loadContent(page, FIXTURE);
+    await setSourceView(page);
+    await page.keyboard.press(`${MOD}+f`);
+    const input = page.locator('.search-input');
+    await input.fill('c');
+
+    // Single character should not trigger a search.
+    const matchCount = page.locator('.search-match-count');
+    await expect(matchCount).toHaveText('');
+
+    const marks = page.locator('#editor mark.search-highlight');
+    await expect(marks).toHaveCount(0);
+
+    await page.keyboard.press('Escape');
+});
+
+test('regex search still works with single character', async () => {
+    await loadContent(page, FIXTURE);
+    await setSourceView(page);
+    await page.keyboard.press(`${MOD}+f`);
+
+    await page.locator('.search-toggle[data-action="regex"]').click();
+    const input = page.locator('.search-input');
+    await input.fill('c');
+
+    // Regex mode should allow single char.
+    const marks = page.locator('#editor mark.search-highlight');
+    expect(await marks.count()).toBeGreaterThan(0);
+
+    await page.locator('.search-toggle[data-action="regex"]').click();
+    await page.keyboard.press('Escape');
+});
+
+// ─── Cursor proximity ───────────────────────────────────────────────
+
+test('initial match is closest to cursor position', async () => {
+    await loadContent(page, FIXTURE);
+    await setSourceView(page);
+
+    // Place cursor at the start of "## Another heading" by clicking it.
+    const secondHeading = page.locator('#editor .md-line', { hasText: 'Another heading' });
+    await secondHeading.click();
+
+    await page.keyboard.press(`${MOD}+f`);
+    const input = page.locator('.search-input');
+    await input.fill('item');
+
+    // 'item' appears in "List item one" and "List item two", both
+    // after the cursor.  The active match should NOT be "1 of" if
+    // there were earlier matches — there aren't any earlier "item"
+    // matches here, but the key point is it picks the closest one
+    // at or after the cursor, which is the first list item.
+    const matchCount = page.locator('.search-match-count');
+    await expect(matchCount).toContainText('1 of');
+
+    // Now search for 'heading' — it appears in heading1 (before cursor)
+    // and heading2 (at cursor).  The active match should be the one
+    // at/after the cursor, i.e. the second heading.
+    await input.fill('heading');
+    await expect(matchCount).toContainText('2 of');
+
+    await page.keyboard.press('Escape');
+});


### PR DESCRIPTION
## Add search feature (closes #57)

### What was missing

The editor had no way to search for text within a document. Issue #57 requested plain text and regex search in both source and focused view.

### What changed

**New files:**
- `src/renderer/scripts/search/search-bar.js` — `SearchBar` class implementing the full search UI and matching logic
- `src/renderer/styles/search.css` — styles for the floating draggable search panel and match highlights
- `test/integration/search.spec.js` — 21 integration tests covering all search functionality

**Modified files:**
- `src/renderer/scripts/parser/syntax-tree.js` — added `toBareText()` on both `SyntaxNode` and `SyntaxTree`, plus `_extractInlineText()` and `_segmentsToText()` static helpers. This method strips all markdown formatting syntax (bold/italic delimiters, link URLs, images, heading prefixes, etc.) and returns only the visible plain text, used for focused-view search matching.
- `src/renderer/scripts/editor/editor.js` — normalizes excessive blank lines (`\n{3,}` → `\n\n`) on load so `toMarkdown()`/`toBareText()` produce consistent separators; dispatches `editor:renderComplete` events after `fullRender()` and `renderNodes()` so the search bar can re-apply highlights after re-renders.
- `src/renderer/scripts/handlers/keyboard-handler.js` — added Ctrl+F (Cmd+F on macOS) shortcut that dispatches `search:open`.
- `src/renderer/scripts/app.js` — imports and initializes `SearchBar`, listens for `search:open` events.
- `src/renderer/index.html` — links `search.css`.
- `test/unit/parser/syntax-tree.test.js` — 16 new unit tests for `toBareText()` covering all node types.

### Design decisions

- **Source view** searches against `syntaxTree.toMarkdown()` (raw markdown including syntax), so users can find formatting markers like `**` or `##`.
- **Focused view** searches against `syntaxTree.toBareText()` (visible rendered text only), so `**bold**` is searched as just `bold`.
- **Focused view plain-text search is per-element** — matches don't cross block boundaries, which feels more natural in WYSIWYG mode. Regex search in either view can still match across elements.
- **Minimum 2 characters** required for plain-text search to avoid overwhelming single-letter hit counts in large documents. Regex mode has no minimum.
- **Cursor proximity** — the initial active match is the one closest to (at or after) the current cursor position, not always the first match in the document.
- **Floating draggable panel** — the search bar is positioned as an absolute modal in the top-right corner with drag-to-reposition support, rather than an inline bar that shifts document content. Position resets on each open.
- **Instant scroll** — navigating between matches jumps immediately rather than smooth-scrolling, which felt disorienting in practice.