### PR TITLE
Add DFA-based tokenizer and parser with unit tests (issue #63)

### DIFF
--- a/scripts/parse-markdown.js
+++ b/scripts/parse-markdown.js
@@ -1,0 +1,63 @@
+/**
+ * CLI script that parses markdown input using the DFA tokenizer/parser
+ * and prints the resulting syntax tree.
+ *
+ * Usage:
+ *   node scripts/parse-markdown.js "# Hello\n\nSome text"
+ *   node scripts/parse-markdown.js --file path/to/file.md
+ */
+
+import { existsSync, readFileSync } from 'node:fs';
+import { DFAParser } from '../src/renderer/scripts/parser/dfa-parser.js';
+
+const args = process.argv.slice(2);
+
+if (args.length === 0) {
+    console.log('Usage:');
+    console.log('  node scripts/parse-markdown.js "# Hello\\n\\nSome text"');
+    console.log('  node scripts/parse-markdown.js --file path/to/file.md');
+    process.exit(1);
+}
+
+let input;
+if (args[0] === '--file') {
+    if (!args[1]) {
+        console.error('Error: --file requires a path argument');
+        process.exit(1);
+    }
+    if (!existsSync(args[1])) {
+        console.error(`Error: file not found: ${args[1]}`);
+        process.exit(1);
+    }
+    input = readFileSync(args[1], 'utf-8');
+} else {
+    input = args.join(' ').replace(/\\n/g, '\n');
+}
+
+console.log('=== Input ===');
+console.log(input);
+console.log();
+
+console.log('=== Syntax Tree ===');
+const parser = new DFAParser();
+const tree = parser.parse(input);
+
+function printNode(/** @type {any} */ node, /** @type {string} */ indent) {
+    const attrs =
+        Object.keys(node.attributes).length > 0 ? ` ${JSON.stringify(node.attributes)}` : '';
+    const content = node.content
+        ? ` "${node.content.length > 60 ? `${node.content.slice(0, 60)}...` : node.content}"`
+        : '';
+    console.log(`${indent}${node.type}${content}${attrs}  [L${node.startLine}-${node.endLine}]`);
+    for (const child of node.children) {
+        printNode(child, `${indent}  `);
+    }
+}
+
+for (const child of tree.children) {
+    printNode(child, '  ');
+}
+
+console.log();
+console.log('=== Round-trip ===');
+console.log(tree.toMarkdown());

--- a/src/renderer/scripts/parser/dfa-parser.js
+++ b/src/renderer/scripts/parser/dfa-parser.js
@@ -1,0 +1,1364 @@
+/**
+ * @fileoverview DFA-based markdown parser.
+ *
+ * Consumes a token stream produced by {@link tokenize} and walks a
+ * deterministic finite automaton to build a {@link SyntaxTree}.
+ * No regex is used.  Newlines are tokens like any other character;
+ * the input is never split into lines.
+ */
+
+import { tokenize } from './dfa-tokenizer.js';
+import { SyntaxNode, SyntaxTree } from './syntax-tree.js';
+
+// ── Block-level HTML tag set (GFM type 6) ───────────────────────────
+
+/** @type {Set<string>} */
+const HTML_BLOCK_TAGS = new Set([
+    'address',
+    'article',
+    'aside',
+    'base',
+    'basefont',
+    'blockquote',
+    'body',
+    'caption',
+    'center',
+    'col',
+    'colgroup',
+    'dd',
+    'details',
+    'dialog',
+    'dir',
+    'div',
+    'dl',
+    'dt',
+    'fieldset',
+    'figcaption',
+    'figure',
+    'footer',
+    'form',
+    'frame',
+    'frameset',
+    'h1',
+    'h2',
+    'h3',
+    'h4',
+    'h5',
+    'h6',
+    'head',
+    'header',
+    'hr',
+    'html',
+    'iframe',
+    'legend',
+    'li',
+    'link',
+    'main',
+    'menu',
+    'menuitem',
+    'nav',
+    'noframes',
+    'ol',
+    'optgroup',
+    'option',
+    'p',
+    'param',
+    'search',
+    'script',
+    'section',
+    'source',
+    'summary',
+    'table',
+    'tbody',
+    'td',
+    'tfoot',
+    'th',
+    'thead',
+    'title',
+    'tr',
+    'track',
+    'ul',
+]);
+
+// ── Helper: count newlines in a string ──────────────────────────────
+
+/**
+ * @param {string} s
+ * @returns {number}
+ */
+function countNewlines(s) {
+    let n = 0;
+    for (let i = 0; i < s.length; i++) {
+        if (s[i] === '\n') n++;
+    }
+    return n;
+}
+
+// ── DFA Parser ──────────────────────────────────────────────────────
+
+/**
+ * Parses markdown text into a syntax tree using a token-driven DFA.
+ */
+export class DFAParser {
+    /**
+     * Parses a full markdown document.
+     * @param {string} markdown
+     * @returns {SyntaxTree}
+     */
+    parse(markdown) {
+        const tokens = tokenize(markdown);
+        const tree = new SyntaxTree();
+        const ctx = { tokens, pos: 0, line: 0 };
+
+        while (ctx.pos < ctx.tokens.length && ctx.tokens[ctx.pos].type !== 'EOF') {
+            // Skip blank lines between blocks
+            if (ctx.tokens[ctx.pos].type === 'NEWLINE') {
+                ctx.line++;
+                ctx.pos++;
+                continue;
+            }
+
+            const node = this._parseBlock(ctx);
+            if (node) {
+                tree.appendChild(node);
+            }
+        }
+
+        return tree;
+    }
+
+    /**
+     * Parses a single line of markdown (for live-editing re-parse).
+     * @param {string} line
+     * @returns {SyntaxNode|null}
+     */
+    parseSingleLine(line) {
+        const tokens = tokenize(line);
+        const ctx = { tokens, pos: 0, line: 0 };
+
+        // Skip leading newlines
+        while (ctx.pos < ctx.tokens.length && ctx.tokens[ctx.pos].type === 'NEWLINE') {
+            ctx.pos++;
+        }
+
+        if (ctx.pos >= ctx.tokens.length || ctx.tokens[ctx.pos].type === 'EOF') {
+            return null;
+        }
+
+        return this._parseBlock(ctx);
+    }
+
+    // ── Block dispatch ──────────────────────────────────────────
+
+    /**
+     * Determines what block element starts at the current position
+     * and dispatches to the appropriate sub-parser.
+     *
+     * @param {{tokens: import('./dfa-tokenizer.js').DFAToken[], pos: number, line: number}} ctx
+     * @returns {SyntaxNode|null}
+     */
+    _parseBlock(ctx) {
+        const tok = ctx.tokens[ctx.pos];
+
+        // Heading: one or more HASH at start of line
+        if (tok.type === 'HASH') {
+            return this._parseHeading(ctx);
+        }
+
+        // Code fence: three BACKTICK tokens
+        if (
+            tok.type === 'BACKTICK' &&
+            this._lookType(ctx, 1) === 'BACKTICK' &&
+            this._lookType(ctx, 2) === 'BACKTICK'
+        ) {
+            return this._parseCodeBlock(ctx);
+        }
+
+        // Blockquote: GT at start
+        if (tok.type === 'GT') {
+            return this._parseBlockquote(ctx);
+        }
+
+        // Unordered list: DASH/STAR/PLUS followed by SPACE, or indented
+        if (this._isUnorderedListStart(ctx)) {
+            return this._parseUnorderedListItem(ctx);
+        }
+
+        // Ordered list: DIGIT(s) DOT SPACE
+        if (this._isOrderedListStart(ctx)) {
+            return this._parseOrderedListItem(ctx);
+        }
+
+        // Horizontal rule: three or more DASH/STAR/UNDERSCORE
+        if (this._isHorizontalRule(ctx)) {
+            return this._parseHorizontalRule(ctx);
+        }
+
+        // HTML img tag: <img ...> (possibly indented)
+        if (tok.type === 'LT' && this._isHtmlImgTag(ctx)) {
+            return this._parseHtmlImage(ctx);
+        }
+        if ((tok.type === 'SPACE' || tok.type === 'TAB') && this._isIndentedHtmlImgTag(ctx)) {
+            this._skipWhitespace(ctx);
+            return this._parseHtmlImage(ctx);
+        }
+
+        // HTML block: <tagname...> (possibly indented)
+        if (tok.type === 'LT' && this._isHtmlBlockStart(ctx)) {
+            return this._parseHtmlBlock(ctx);
+        }
+        if ((tok.type === 'SPACE' || tok.type === 'TAB') && this._isIndentedHtmlBlockStart(ctx)) {
+            this._skipWhitespace(ctx);
+            return this._parseHtmlBlock(ctx);
+        }
+
+        // Table: starts with PIPE
+        if (tok.type === 'PIPE') {
+            return this._parseTable(ctx);
+        }
+
+        // Linked image: [![alt](src)](href)
+        if (tok.type === 'LBRACKET' && this._lookType(ctx, 1) === 'BANG') {
+            const saved = ctx.pos;
+            const node = this._tryParseLinkedImage(ctx);
+            if (node) return node;
+            ctx.pos = saved;
+        }
+
+        // Image: ![alt](src)
+        if (tok.type === 'BANG' && this._lookType(ctx, 1) === 'LBRACKET') {
+            const saved = ctx.pos;
+            const node = this._tryParseImage(ctx);
+            if (node) return node;
+            ctx.pos = saved;
+        }
+
+        // Default: paragraph
+        return this._parseParagraph(ctx);
+    }
+
+    // ── Heading ─────────────────────────────────────────────────
+
+    /**
+     * @param {{tokens: import('./dfa-tokenizer.js').DFAToken[], pos: number, line: number}} ctx
+     * @returns {SyntaxNode}
+     */
+    _parseHeading(ctx) {
+        const startLine = ctx.line;
+        let level = 0;
+
+        // Count hashes
+        while (ctx.pos < ctx.tokens.length && ctx.tokens[ctx.pos].type === 'HASH') {
+            level++;
+            ctx.pos++;
+        }
+
+        if (level > 6) level = 6;
+
+        // Skip the space after hashes
+        if (ctx.pos < ctx.tokens.length && ctx.tokens[ctx.pos].type === 'SPACE') {
+            ctx.pos++;
+        }
+
+        // Collect content until NEWLINE or EOF
+        const content = this._consumeToEndOfLine(ctx);
+
+        const node = new SyntaxNode(`heading${level}`, content);
+        node.startLine = startLine;
+        node.endLine = startLine;
+        return node;
+    }
+
+    // ── Code block ──────────────────────────────────────────────
+
+    /**
+     * @param {{tokens: import('./dfa-tokenizer.js').DFAToken[], pos: number, line: number}} ctx
+     * @returns {SyntaxNode}
+     */
+    _parseCodeBlock(ctx) {
+        const startLine = ctx.line;
+
+        // Skip the three backticks
+        ctx.pos += 3;
+
+        // Collect language identifier (until NEWLINE or EOF)
+        let language = '';
+        while (
+            ctx.pos < ctx.tokens.length &&
+            ctx.tokens[ctx.pos].type !== 'NEWLINE' &&
+            ctx.tokens[ctx.pos].type !== 'EOF'
+        ) {
+            language += ctx.tokens[ctx.pos].value;
+            ctx.pos++;
+        }
+        language = language.trim();
+
+        // Skip the newline after opening fence
+        if (ctx.pos < ctx.tokens.length && ctx.tokens[ctx.pos].type === 'NEWLINE') {
+            ctx.line++;
+            ctx.pos++;
+        }
+
+        // Collect body until closing fence (three backticks at start of line)
+        let content = '';
+        while (ctx.pos < ctx.tokens.length && ctx.tokens[ctx.pos].type !== 'EOF') {
+            // Check for closing fence: three backticks
+            if (
+                ctx.tokens[ctx.pos].type === 'BACKTICK' &&
+                this._lookType(ctx, 1) === 'BACKTICK' &&
+                this._lookType(ctx, 2) === 'BACKTICK'
+            ) {
+                // Closing fence found — skip the backticks
+                ctx.pos += 3;
+                // Skip optional trailing content on the fence line
+                while (
+                    ctx.pos < ctx.tokens.length &&
+                    ctx.tokens[ctx.pos].type !== 'NEWLINE' &&
+                    ctx.tokens[ctx.pos].type !== 'EOF'
+                ) {
+                    ctx.pos++;
+                }
+                // Skip the newline after closing fence
+                if (ctx.pos < ctx.tokens.length && ctx.tokens[ctx.pos].type === 'NEWLINE') {
+                    ctx.line++;
+                    ctx.pos++;
+                }
+                break;
+            }
+
+            if (ctx.tokens[ctx.pos].type === 'NEWLINE') {
+                content += '\n';
+                ctx.line++;
+            } else {
+                content += ctx.tokens[ctx.pos].value;
+            }
+            ctx.pos++;
+        }
+
+        // Remove trailing newline from content if present
+        if (content.endsWith('\n')) {
+            content = content.slice(0, -1);
+        }
+
+        const node = new SyntaxNode('code-block', content);
+        node.attributes = { language };
+        node.startLine = startLine;
+        node.endLine = ctx.line > startLine ? ctx.line - 1 : startLine;
+        return node;
+    }
+
+    // ── Blockquote ──────────────────────────────────────────────
+
+    /**
+     * @param {{tokens: import('./dfa-tokenizer.js').DFAToken[], pos: number, line: number}} ctx
+     * @returns {SyntaxNode}
+     */
+    _parseBlockquote(ctx) {
+        const startLine = ctx.line;
+        const contentLines = [];
+
+        while (ctx.pos < ctx.tokens.length && ctx.tokens[ctx.pos].type === 'GT') {
+            // Skip GT
+            ctx.pos++;
+            // Skip optional space after >
+            if (ctx.pos < ctx.tokens.length && ctx.tokens[ctx.pos].type === 'SPACE') {
+                ctx.pos++;
+            }
+            // Collect to end of line
+            contentLines.push(this._consumeToEndOfLine(ctx));
+        }
+
+        const node = new SyntaxNode('blockquote', contentLines.join('\n'));
+        node.startLine = startLine;
+        node.endLine = ctx.line > startLine ? ctx.line - 1 : startLine;
+        return node;
+    }
+
+    // ── List items ──────────────────────────────────────────────
+
+    /**
+     * Checks if current position is start of unordered list item.
+     * Pattern: optional spaces, then DASH/STAR/PLUS, then SPACE.
+     * @param {{tokens: import('./dfa-tokenizer.js').DFAToken[], pos: number}} ctx
+     * @returns {boolean}
+     */
+    _isUnorderedListStart(ctx) {
+        let i = ctx.pos;
+        // Skip leading spaces
+        while (
+            i < ctx.tokens.length &&
+            (ctx.tokens[i].type === 'SPACE' || ctx.tokens[i].type === 'TAB')
+        ) {
+            i++;
+        }
+        // Must be DASH, STAR, or PLUS
+        if (i >= ctx.tokens.length) return false;
+        const t = ctx.tokens[i].type;
+        if (t !== 'DASH' && t !== 'STAR' && t !== 'PLUS') return false;
+        // Followed by SPACE
+        i++;
+        if (i >= ctx.tokens.length) return false;
+        return ctx.tokens[i].type === 'SPACE';
+    }
+
+    /**
+     * @param {{tokens: import('./dfa-tokenizer.js').DFAToken[], pos: number, line: number}} ctx
+     * @returns {SyntaxNode}
+     */
+    _parseUnorderedListItem(ctx) {
+        const startLine = ctx.line;
+
+        // Count leading spaces for indent
+        let spaces = 0;
+        while (
+            ctx.pos < ctx.tokens.length &&
+            (ctx.tokens[ctx.pos].type === 'SPACE' || ctx.tokens[ctx.pos].type === 'TAB')
+        ) {
+            spaces += ctx.tokens[ctx.pos].type === 'TAB' ? 2 : 1;
+            ctx.pos++;
+        }
+        const indent = Math.floor(spaces / 2);
+
+        // Skip the marker (DASH/STAR/PLUS)
+        ctx.pos++;
+        // Skip the SPACE after marker
+        if (ctx.pos < ctx.tokens.length && ctx.tokens[ctx.pos].type === 'SPACE') {
+            ctx.pos++;
+        }
+
+        const content = this._consumeToEndOfLine(ctx);
+
+        const node = new SyntaxNode('list-item', content);
+        node.attributes = { ordered: false, indent };
+        node.startLine = startLine;
+        node.endLine = startLine;
+        return node;
+    }
+
+    /**
+     * Checks if current position is start of ordered list item.
+     * Pattern: optional spaces, then DIGIT(s), then DOT, then SPACE.
+     * @param {{tokens: import('./dfa-tokenizer.js').DFAToken[], pos: number}} ctx
+     * @returns {boolean}
+     */
+    _isOrderedListStart(ctx) {
+        let i = ctx.pos;
+        // Skip leading spaces
+        while (
+            i < ctx.tokens.length &&
+            (ctx.tokens[i].type === 'SPACE' || ctx.tokens[i].type === 'TAB')
+        ) {
+            i++;
+        }
+        // Must have at least one DIGIT
+        if (i >= ctx.tokens.length || ctx.tokens[i].type !== 'DIGIT') return false;
+        while (i < ctx.tokens.length && ctx.tokens[i].type === 'DIGIT') {
+            i++;
+        }
+        // Then DOT
+        if (i >= ctx.tokens.length || ctx.tokens[i].type !== 'DOT') return false;
+        i++;
+        // Then SPACE
+        if (i >= ctx.tokens.length || ctx.tokens[i].type !== 'SPACE') return false;
+        return true;
+    }
+
+    /**
+     * @param {{tokens: import('./dfa-tokenizer.js').DFAToken[], pos: number, line: number}} ctx
+     * @returns {SyntaxNode}
+     */
+    _parseOrderedListItem(ctx) {
+        const startLine = ctx.line;
+
+        // Count leading spaces for indent
+        let spaces = 0;
+        while (
+            ctx.pos < ctx.tokens.length &&
+            (ctx.tokens[ctx.pos].type === 'SPACE' || ctx.tokens[ctx.pos].type === 'TAB')
+        ) {
+            spaces += ctx.tokens[ctx.pos].type === 'TAB' ? 2 : 1;
+            ctx.pos++;
+        }
+        const indent = Math.floor(spaces / 2);
+
+        // Collect digit chars for the number
+        let numStr = '';
+        while (ctx.pos < ctx.tokens.length && ctx.tokens[ctx.pos].type === 'DIGIT') {
+            numStr += ctx.tokens[ctx.pos].value;
+            ctx.pos++;
+        }
+        const number = Number.parseInt(numStr, 10);
+
+        // Skip DOT
+        ctx.pos++;
+        // Skip SPACE
+        if (ctx.pos < ctx.tokens.length && ctx.tokens[ctx.pos].type === 'SPACE') {
+            ctx.pos++;
+        }
+
+        const content = this._consumeToEndOfLine(ctx);
+
+        const node = new SyntaxNode('list-item', content);
+        node.attributes = { ordered: true, number, indent };
+        node.startLine = startLine;
+        node.endLine = startLine;
+        return node;
+    }
+
+    // ── Horizontal rule ─────────────────────────────────────────
+
+    /**
+     * Checks if current position is a horizontal rule.
+     * Three or more of the same character (DASH, STAR, UNDERSCORE)
+     * with only optional trailing spaces before newline/EOF.
+     * @param {{tokens: import('./dfa-tokenizer.js').DFAToken[], pos: number}} ctx
+     * @returns {boolean}
+     */
+    _isHorizontalRule(ctx) {
+        const t = ctx.tokens[ctx.pos].type;
+        if (t !== 'DASH' && t !== 'STAR' && t !== 'UNDERSCORE') return false;
+
+        let i = ctx.pos;
+        let count = 0;
+        while (i < ctx.tokens.length && ctx.tokens[i].type === t) {
+            count++;
+            i++;
+        }
+        if (count < 3) return false;
+
+        // Only spaces allowed after the run, then NEWLINE or EOF
+        while (i < ctx.tokens.length && ctx.tokens[i].type === 'SPACE') {
+            i++;
+        }
+        return (
+            i >= ctx.tokens.length ||
+            ctx.tokens[i].type === 'NEWLINE' ||
+            ctx.tokens[i].type === 'EOF'
+        );
+    }
+
+    /**
+     * @param {{tokens: import('./dfa-tokenizer.js').DFAToken[], pos: number, line: number}} ctx
+     * @returns {SyntaxNode}
+     */
+    _parseHorizontalRule(ctx) {
+        const startLine = ctx.line;
+
+        // Consume all the markers and trailing spaces
+        this._consumeToEndOfLine(ctx);
+
+        const node = new SyntaxNode('horizontal-rule', '');
+        node.startLine = startLine;
+        node.endLine = startLine;
+        return node;
+    }
+
+    // ── Images ──────────────────────────────────────────────────
+
+    /**
+     * Tries to parse ![alt](src). Returns null if it doesn't match.
+     * @param {{tokens: import('./dfa-tokenizer.js').DFAToken[], pos: number, line: number}} ctx
+     * @returns {SyntaxNode|null}
+     */
+    _tryParseImage(ctx) {
+        const startLine = ctx.line;
+
+        // Expect BANG LBRACKET
+        if (ctx.tokens[ctx.pos].type !== 'BANG') return null;
+        ctx.pos++;
+        if (ctx.pos >= ctx.tokens.length || ctx.tokens[ctx.pos].type !== 'LBRACKET') return null;
+        ctx.pos++;
+
+        // Collect alt text until RBRACKET
+        let alt = '';
+        while (
+            ctx.pos < ctx.tokens.length &&
+            ctx.tokens[ctx.pos].type !== 'RBRACKET' &&
+            ctx.tokens[ctx.pos].type !== 'NEWLINE' &&
+            ctx.tokens[ctx.pos].type !== 'EOF'
+        ) {
+            alt += ctx.tokens[ctx.pos].value;
+            ctx.pos++;
+        }
+        if (ctx.pos >= ctx.tokens.length || ctx.tokens[ctx.pos].type !== 'RBRACKET') return null;
+        ctx.pos++; // skip ]
+
+        // Expect LPAREN
+        if (ctx.pos >= ctx.tokens.length || ctx.tokens[ctx.pos].type !== 'LPAREN') return null;
+        ctx.pos++;
+
+        // Collect src until RPAREN
+        let src = '';
+        while (
+            ctx.pos < ctx.tokens.length &&
+            ctx.tokens[ctx.pos].type !== 'RPAREN' &&
+            ctx.tokens[ctx.pos].type !== 'NEWLINE' &&
+            ctx.tokens[ctx.pos].type !== 'EOF'
+        ) {
+            src += ctx.tokens[ctx.pos].value;
+            ctx.pos++;
+        }
+        if (ctx.pos >= ctx.tokens.length || ctx.tokens[ctx.pos].type !== 'RPAREN') return null;
+        ctx.pos++; // skip )
+
+        // Must be end of line for a block-level image
+        if (
+            ctx.pos < ctx.tokens.length &&
+            ctx.tokens[ctx.pos].type !== 'NEWLINE' &&
+            ctx.tokens[ctx.pos].type !== 'EOF'
+        ) {
+            return null;
+        }
+        // Skip newline
+        if (ctx.pos < ctx.tokens.length && ctx.tokens[ctx.pos].type === 'NEWLINE') {
+            ctx.line++;
+            ctx.pos++;
+        }
+
+        const node = new SyntaxNode('image', alt);
+        node.attributes = { alt, url: src };
+        node.startLine = startLine;
+        node.endLine = startLine;
+        return node;
+    }
+
+    /**
+     * Tries to parse [![alt](src)](href). Returns null if no match.
+     * @param {{tokens: import('./dfa-tokenizer.js').DFAToken[], pos: number, line: number}} ctx
+     * @returns {SyntaxNode|null}
+     */
+    _tryParseLinkedImage(ctx) {
+        const startLine = ctx.line;
+
+        // Expect [ ! [
+        if (ctx.tokens[ctx.pos].type !== 'LBRACKET') return null;
+        ctx.pos++;
+        if (ctx.pos >= ctx.tokens.length || ctx.tokens[ctx.pos].type !== 'BANG') return null;
+        ctx.pos++;
+        if (ctx.pos >= ctx.tokens.length || ctx.tokens[ctx.pos].type !== 'LBRACKET') return null;
+        ctx.pos++;
+
+        // Collect alt until ]
+        let alt = '';
+        while (
+            ctx.pos < ctx.tokens.length &&
+            ctx.tokens[ctx.pos].type !== 'RBRACKET' &&
+            ctx.tokens[ctx.pos].type !== 'NEWLINE' &&
+            ctx.tokens[ctx.pos].type !== 'EOF'
+        ) {
+            alt += ctx.tokens[ctx.pos].value;
+            ctx.pos++;
+        }
+        if (ctx.pos >= ctx.tokens.length || ctx.tokens[ctx.pos].type !== 'RBRACKET') return null;
+        ctx.pos++; // ]
+
+        // Expect (
+        if (ctx.pos >= ctx.tokens.length || ctx.tokens[ctx.pos].type !== 'LPAREN') return null;
+        ctx.pos++;
+
+        // Collect src until )
+        let src = '';
+        while (
+            ctx.pos < ctx.tokens.length &&
+            ctx.tokens[ctx.pos].type !== 'RPAREN' &&
+            ctx.tokens[ctx.pos].type !== 'NEWLINE' &&
+            ctx.tokens[ctx.pos].type !== 'EOF'
+        ) {
+            src += ctx.tokens[ctx.pos].value;
+            ctx.pos++;
+        }
+        if (ctx.pos >= ctx.tokens.length || ctx.tokens[ctx.pos].type !== 'RPAREN') return null;
+        ctx.pos++; // )
+
+        // Expect ] (
+        if (ctx.pos >= ctx.tokens.length || ctx.tokens[ctx.pos].type !== 'RBRACKET') return null;
+        ctx.pos++;
+        if (ctx.pos >= ctx.tokens.length || ctx.tokens[ctx.pos].type !== 'LPAREN') return null;
+        ctx.pos++;
+
+        // Collect href until )
+        let href = '';
+        while (
+            ctx.pos < ctx.tokens.length &&
+            ctx.tokens[ctx.pos].type !== 'RPAREN' &&
+            ctx.tokens[ctx.pos].type !== 'NEWLINE' &&
+            ctx.tokens[ctx.pos].type !== 'EOF'
+        ) {
+            href += ctx.tokens[ctx.pos].value;
+            ctx.pos++;
+        }
+        if (ctx.pos >= ctx.tokens.length || ctx.tokens[ctx.pos].type !== 'RPAREN') return null;
+        ctx.pos++; // )
+
+        // Must be end of line for block-level
+        if (
+            ctx.pos < ctx.tokens.length &&
+            ctx.tokens[ctx.pos].type !== 'NEWLINE' &&
+            ctx.tokens[ctx.pos].type !== 'EOF'
+        ) {
+            return null;
+        }
+        if (ctx.pos < ctx.tokens.length && ctx.tokens[ctx.pos].type === 'NEWLINE') {
+            ctx.line++;
+            ctx.pos++;
+        }
+
+        const node = new SyntaxNode('image', alt);
+        node.attributes = { alt, url: src, href };
+        node.startLine = startLine;
+        node.endLine = startLine;
+        return node;
+    }
+
+    // ── HTML image ──────────────────────────────────────────────
+
+    /**
+     * Checks if current position is an <img ...> tag.
+     * @param {{tokens: import('./dfa-tokenizer.js').DFAToken[], pos: number}} ctx
+     * @returns {boolean}
+     */
+    _isHtmlImgTag(ctx) {
+        // LT then "img" (case-insensitive)
+        const after = this._peekTextAfterLT(ctx);
+        if (!after) return false;
+        return after.toLowerCase() === 'img';
+    }
+
+    /**
+     * @param {{tokens: import('./dfa-tokenizer.js').DFAToken[], pos: number, line: number}} ctx
+     * @returns {SyntaxNode}
+     */
+    _parseHtmlImage(ctx) {
+        const startLine = ctx.line;
+
+        // Consume everything until GT (the closing >)
+        let raw = '';
+        while (
+            ctx.pos < ctx.tokens.length &&
+            ctx.tokens[ctx.pos].type !== 'NEWLINE' &&
+            ctx.tokens[ctx.pos].type !== 'EOF'
+        ) {
+            raw += ctx.tokens[ctx.pos].value;
+            if (ctx.tokens[ctx.pos].type === 'GT' && raw.length > 1) {
+                ctx.pos++;
+                break;
+            }
+            ctx.pos++;
+        }
+
+        // Skip newline
+        if (ctx.pos < ctx.tokens.length && ctx.tokens[ctx.pos].type === 'NEWLINE') {
+            ctx.line++;
+            ctx.pos++;
+        }
+
+        // Extract attributes by scanning the raw string character by character
+        const src = this._extractAttr(raw, 'src');
+        const alt = this._extractAttr(raw, 'alt');
+        const style = this._extractAttr(raw, 'style');
+
+        const node = new SyntaxNode('image', alt);
+        node.attributes = { alt, url: src };
+        if (style) {
+            node.attributes.style = style;
+        }
+        node.startLine = startLine;
+        node.endLine = startLine;
+        return node;
+    }
+
+    /**
+     * Extracts an attribute value from an HTML tag string without regex.
+     * Scans for `name="value"` or `name='value'` patterns.
+     * @param {string} raw
+     * @param {string} name
+     * @returns {string}
+     */
+    _extractAttr(raw, name) {
+        const lower = raw.toLowerCase();
+        const search = name.toLowerCase();
+        let i = 0;
+
+        while (i < lower.length) {
+            const idx = lower.indexOf(search, i);
+            if (idx === -1) return '';
+
+            // Check this is actually an attribute name boundary
+            let j = idx + search.length;
+
+            // Skip whitespace around =
+            while (j < lower.length && (lower[j] === ' ' || lower[j] === '\t')) j++;
+            if (j >= lower.length || lower[j] !== '=') {
+                i = idx + 1;
+                continue;
+            }
+            j++; // skip =
+            while (j < lower.length && (lower[j] === ' ' || lower[j] === '\t')) j++;
+
+            // Expect quote
+            if (j >= lower.length) return '';
+            const quote = raw[j];
+            if (quote !== '"' && quote !== "'") {
+                i = idx + 1;
+                continue;
+            }
+            j++; // skip opening quote
+
+            // Collect until closing quote
+            let value = '';
+            while (j < raw.length && raw[j] !== quote) {
+                value += raw[j];
+                j++;
+            }
+            return value;
+        }
+        return '';
+    }
+
+    // ── HTML block ──────────────────────────────────────────────
+
+    /**
+     * Checks if current position starts an HTML block tag.
+     * @param {{tokens: import('./dfa-tokenizer.js').DFAToken[], pos: number}} ctx
+     * @returns {boolean}
+     */
+    _isHtmlBlockStart(ctx) {
+        const tagName = this._peekTextAfterLT(ctx);
+        if (!tagName) return false;
+        const lower = tagName.toLowerCase();
+        return HTML_BLOCK_TAGS.has(lower) || this._isValidCustomElement(lower);
+    }
+
+    /**
+     * Checks if current position has leading whitespace followed by
+     * an HTML block tag.
+     * @param {{tokens: import('./dfa-tokenizer.js').DFAToken[], pos: number}} ctx
+     * @returns {boolean}
+     */
+    _isIndentedHtmlBlockStart(ctx) {
+        let i = ctx.pos;
+        while (
+            i < ctx.tokens.length &&
+            (ctx.tokens[i].type === 'SPACE' || ctx.tokens[i].type === 'TAB')
+        ) {
+            i++;
+        }
+        if (i >= ctx.tokens.length || i === ctx.pos) return false;
+        if (ctx.tokens[i].type !== 'LT') return false;
+        const result = this._peekTagName(ctx.tokens, i + 1);
+        if (!result) return false;
+        const lower = result.name.toLowerCase();
+        return HTML_BLOCK_TAGS.has(lower) || this._isValidCustomElement(lower);
+    }
+
+    /**
+     * Checks if current position has leading whitespace followed by
+     * an HTML img tag.
+     * @param {{tokens: import('./dfa-tokenizer.js').DFAToken[], pos: number}} ctx
+     * @returns {boolean}
+     */
+    _isIndentedHtmlImgTag(ctx) {
+        let i = ctx.pos;
+        while (
+            i < ctx.tokens.length &&
+            (ctx.tokens[i].type === 'SPACE' || ctx.tokens[i].type === 'TAB')
+        ) {
+            i++;
+        }
+        if (i >= ctx.tokens.length || i === ctx.pos) return false;
+        if (ctx.tokens[i].type !== 'LT') return false;
+        const next = i + 1;
+        if (next >= ctx.tokens.length || ctx.tokens[next].type !== 'TEXT') return false;
+        return ctx.tokens[next].value.toLowerCase() === 'img';
+    }
+
+    /**
+     * Skips whitespace tokens (SPACE, TAB) at current position.
+     * @param {{tokens: import('./dfa-tokenizer.js').DFAToken[], pos: number}} ctx
+     */
+    _skipWhitespace(ctx) {
+        while (
+            ctx.pos < ctx.tokens.length &&
+            (ctx.tokens[ctx.pos].type === 'SPACE' || ctx.tokens[ctx.pos].type === 'TAB')
+        ) {
+            ctx.pos++;
+        }
+    }
+
+    /**
+     * Starting from a given index, reads consecutive TEXT and DASH tokens
+     * to form a (possibly hyphenated) tag name. Returns the combined name
+     * string and the number of tokens consumed, or null if the position
+     * does not start with a TEXT token.
+     * @param {import('./dfa-tokenizer.js').DFAToken[]} tokens
+     * @param {number} startIndex
+     * @returns {{name: string, count: number}|null}
+     */
+    _peekTagName(tokens, startIndex) {
+        if (startIndex >= tokens.length || tokens[startIndex].type !== 'TEXT') {
+            return null;
+        }
+        let name = tokens[startIndex].value;
+        let count = 1;
+        let i = startIndex + 1;
+        // Collect alternating DASH TEXT sequences
+        while (
+            i + 1 < tokens.length &&
+            tokens[i].type === 'DASH' &&
+            tokens[i + 1].type === 'TEXT'
+        ) {
+            name += `-${tokens[i + 1].value}`;
+            count += 2;
+            i += 2;
+        }
+        return { name, count };
+    }
+
+    /**
+     * Validates that a tag name is a legal custom element name.
+     * Rules: must start with a letter, contain at least one hyphen
+     * followed by a letter, no consecutive hyphens, must not end
+     * with a hyphen.
+     * @param {string} name
+     * @returns {boolean}
+     */
+    _isValidCustomElement(name) {
+        const parts = name.split('-');
+        if (parts.length < 2) return false;
+        for (const part of parts) {
+            if (part.length === 0) return false;
+        }
+        return true;
+    }
+
+    /**
+     * Peeks at the text token(s) immediately after a LT token to get
+     * the tag name, including hyphenated custom element names.
+     * Returns null if structure doesn't match.
+     * @param {{tokens: import('./dfa-tokenizer.js').DFAToken[], pos: number}} ctx
+     * @returns {string|null}
+     */
+    _peekTextAfterLT(ctx) {
+        if (ctx.tokens[ctx.pos].type !== 'LT') return null;
+        const result = this._peekTagName(ctx.tokens, ctx.pos + 1);
+        if (!result) return null;
+        return result.name;
+    }
+
+    /**
+     * Parses an HTML block element. Consumes everything from the opening
+     * tag through the matching closing tag.
+     *
+     * @param {{tokens: import('./dfa-tokenizer.js').DFAToken[], pos: number, line: number}} ctx
+     * @returns {SyntaxNode}
+     */
+    _parseHtmlBlock(ctx) {
+        const startLine = ctx.line;
+
+        // Consume the opening tag line (everything up to and including the first >)
+        let openingTag = '';
+        const tagName = this._peekTextAfterLT(ctx);
+        const lowerTagName = tagName ? tagName.toLowerCase() : '';
+
+        // Read the entire opening tag up to GT
+        while (
+            ctx.pos < ctx.tokens.length &&
+            ctx.tokens[ctx.pos].type !== 'GT' &&
+            ctx.tokens[ctx.pos].type !== 'NEWLINE' &&
+            ctx.tokens[ctx.pos].type !== 'EOF'
+        ) {
+            openingTag += ctx.tokens[ctx.pos].value;
+            ctx.pos++;
+        }
+        // Include the GT
+        if (ctx.pos < ctx.tokens.length && ctx.tokens[ctx.pos].type === 'GT') {
+            openingTag += '>';
+            ctx.pos++;
+        }
+
+        // Check if this is a self-closed tag on one line: <tag>content</tag>
+        // Look ahead to see if there's content then a closing tag on same line
+        const selfClosedResult = this._trySelfClosedHtmlBlock(
+            ctx,
+            lowerTagName,
+            openingTag,
+            startLine,
+        );
+        if (selfClosedResult) {
+            return selfClosedResult;
+        }
+
+        // Skip newline after opening tag
+        if (ctx.pos < ctx.tokens.length && ctx.tokens[ctx.pos].type === 'NEWLINE') {
+            ctx.line++;
+            ctx.pos++;
+        }
+
+        // Collect body content until we find the closing tag </tagname>
+        let bodyMarkdown = '';
+        let closingTag = '';
+
+        while (ctx.pos < ctx.tokens.length && ctx.tokens[ctx.pos].type !== 'EOF') {
+            // Check for closing tag: LT FSLASH TEXT(tagname) GT
+            if (this._isClosingTag(ctx, lowerTagName)) {
+                closingTag = this._consumeClosingTag(ctx);
+                break;
+            }
+
+            if (ctx.tokens[ctx.pos].type === 'NEWLINE') {
+                bodyMarkdown += '\n';
+                ctx.line++;
+            } else {
+                bodyMarkdown += ctx.tokens[ctx.pos].value;
+            }
+            ctx.pos++;
+        }
+
+        // Remove leading/trailing newlines from body
+        while (bodyMarkdown.startsWith('\n')) bodyMarkdown = bodyMarkdown.slice(1);
+        while (bodyMarkdown.endsWith('\n')) bodyMarkdown = bodyMarkdown.slice(0, -1);
+
+        const endLine = ctx.line;
+
+        // Skip newline after closing tag
+        if (ctx.pos < ctx.tokens.length && ctx.tokens[ctx.pos].type === 'NEWLINE') {
+            ctx.line++;
+            ctx.pos++;
+        }
+
+        // Create the container node
+        const node = new SyntaxNode('html-block', '');
+        node.attributes = {
+            tagName: lowerTagName,
+            openingTag,
+            closingTag,
+        };
+        node.startLine = startLine;
+        node.endLine = endLine;
+
+        // Re-parse the body as markdown to create child nodes
+        if (bodyMarkdown.length > 0) {
+            const bodyParser = new DFAParser();
+            const bodyTree = bodyParser.parse(bodyMarkdown);
+            const bodyStartLine = startLine + 1;
+            for (const child of bodyTree.children) {
+                this._adjustLineNumbers(child, bodyStartLine);
+                node.appendChild(child);
+            }
+        }
+
+        return node;
+    }
+
+    /**
+     * Tries to parse a self-closed HTML block on a single line.
+     * E.g. <summary>Some text</summary>
+     *
+     * @param {{tokens: import('./dfa-tokenizer.js').DFAToken[], pos: number, line: number}} ctx
+     * @param {string} tagName
+     * @param {string} openingTag
+     * @param {number} startLine
+     * @returns {SyntaxNode|null}
+     */
+    _trySelfClosedHtmlBlock(ctx, tagName, openingTag, startLine) {
+        // Save position in case this isn't self-closed
+        const savedPos = ctx.pos;
+        const savedLine = ctx.line;
+
+        // Collect content until NEWLINE or EOF, looking for </tagname>
+        let content = '';
+        let closingFound = false;
+
+        while (
+            ctx.pos < ctx.tokens.length &&
+            ctx.tokens[ctx.pos].type !== 'NEWLINE' &&
+            ctx.tokens[ctx.pos].type !== 'EOF'
+        ) {
+            // Check for closing tag
+            if (this._isClosingTag(ctx, tagName)) {
+                closingFound = true;
+                // Don't consume the closing tag yet
+                break;
+            }
+            content += ctx.tokens[ctx.pos].value;
+            ctx.pos++;
+        }
+
+        if (!closingFound) {
+            // Not self-closed — restore position
+            ctx.pos = savedPos;
+            ctx.line = savedLine;
+            return null;
+        }
+
+        // Skip the closing tag
+        this._consumeClosingTag(ctx);
+
+        // Skip newline
+        if (ctx.pos < ctx.tokens.length && ctx.tokens[ctx.pos].type === 'NEWLINE') {
+            ctx.line++;
+            ctx.pos++;
+        }
+
+        // Build the node structure matching the existing parser's output
+        const node = new SyntaxNode('html-block', '');
+        node.attributes = {
+            tagName,
+            openingTag,
+            closingTag: `</${tagName}>`,
+        };
+        node.startLine = startLine;
+        node.endLine = startLine;
+
+        const child = new SyntaxNode('paragraph', content.trim());
+        child.attributes = { bareText: true };
+        child.startLine = startLine;
+        child.endLine = startLine;
+        node.appendChild(child);
+
+        return node;
+    }
+
+    /**
+     * Checks if current position is a closing tag for the given name.
+     * Pattern: LT FSLASH TEXT GT (where TEXT matches tagName).
+     * @param {{tokens: import('./dfa-tokenizer.js').DFAToken[], pos: number}} ctx
+     * @param {string} tagName
+     * @returns {boolean}
+     */
+    _isClosingTag(ctx, tagName) {
+        const i = ctx.pos;
+        if (i >= ctx.tokens.length || ctx.tokens[i].type !== 'LT') return false;
+        if (i + 1 >= ctx.tokens.length || ctx.tokens[i + 1].type !== 'FSLASH') return false;
+        const result = this._peekTagName(ctx.tokens, i + 2);
+        if (!result) return false;
+        if (result.name.toLowerCase() !== tagName) return false;
+        // Check for optional space then GT
+        let j = i + 2 + result.count;
+        while (j < ctx.tokens.length && ctx.tokens[j].type === 'SPACE') j++;
+        if (j >= ctx.tokens.length || ctx.tokens[j].type !== 'GT') return false;
+        return true;
+    }
+
+    /**
+     * Consumes a closing tag and returns it as a string.
+     * @param {{tokens: import('./dfa-tokenizer.js').DFAToken[], pos: number, line: number}} ctx
+     * @returns {string}
+     */
+    _consumeClosingTag(ctx) {
+        let tag = '';
+        // LT
+        tag += ctx.tokens[ctx.pos].value;
+        ctx.pos++;
+        // FSLASH
+        tag += ctx.tokens[ctx.pos].value;
+        ctx.pos++;
+        // Tag name (TEXT and possibly DASH TEXT pairs)
+        const result = this._peekTagName(ctx.tokens, ctx.pos);
+        if (result) {
+            for (let n = 0; n < result.count; n++) {
+                tag += ctx.tokens[ctx.pos].value;
+                ctx.pos++;
+            }
+        }
+        // Optional spaces
+        while (ctx.pos < ctx.tokens.length && ctx.tokens[ctx.pos].type === 'SPACE') {
+            tag += ctx.tokens[ctx.pos].value;
+            ctx.pos++;
+        }
+        // GT
+        if (ctx.pos < ctx.tokens.length && ctx.tokens[ctx.pos].type === 'GT') {
+            tag += ctx.tokens[ctx.pos].value;
+            ctx.pos++;
+        }
+        return tag;
+    }
+
+    /**
+     * Recursively adjusts line numbers on a node and its children.
+     * @param {SyntaxNode} node
+     * @param {number} offset
+     */
+    _adjustLineNumbers(node, offset) {
+        node.startLine += offset;
+        node.endLine += offset;
+        for (const child of node.children) {
+            this._adjustLineNumbers(child, offset);
+        }
+    }
+
+    // ── Table ───────────────────────────────────────────────────
+
+    /**
+     * @param {{tokens: import('./dfa-tokenizer.js').DFAToken[], pos: number, line: number}} ctx
+     * @returns {SyntaxNode}
+     */
+    _parseTable(ctx) {
+        const startLine = ctx.line;
+        const lines = [];
+
+        // Collect lines that start with PIPE or look like separator rows
+        while (ctx.pos < ctx.tokens.length && ctx.tokens[ctx.pos].type !== 'EOF') {
+            // Check if this line starts with PIPE
+            if (ctx.tokens[ctx.pos].type !== 'PIPE') break;
+
+            // Collect entire line
+            let line = '';
+            while (
+                ctx.pos < ctx.tokens.length &&
+                ctx.tokens[ctx.pos].type !== 'NEWLINE' &&
+                ctx.tokens[ctx.pos].type !== 'EOF'
+            ) {
+                line += ctx.tokens[ctx.pos].value;
+                ctx.pos++;
+            }
+            lines.push(line);
+
+            // Skip newline
+            if (ctx.pos < ctx.tokens.length && ctx.tokens[ctx.pos].type === 'NEWLINE') {
+                ctx.line++;
+                ctx.pos++;
+            }
+        }
+
+        const content = lines.join('\n');
+        const node = new SyntaxNode('table', content);
+        node.startLine = startLine;
+        node.endLine = startLine + lines.length - 1;
+        return node;
+    }
+
+    // ── Paragraph ───────────────────────────────────────────────
+
+    /**
+     * @param {{tokens: import('./dfa-tokenizer.js').DFAToken[], pos: number, line: number}} ctx
+     * @returns {SyntaxNode}
+     */
+    _parseParagraph(ctx) {
+        const startLine = ctx.line;
+        let content = '';
+        let consecutiveNewlines = 0;
+
+        while (ctx.pos < ctx.tokens.length && ctx.tokens[ctx.pos].type !== 'EOF') {
+            if (ctx.tokens[ctx.pos].type === 'NEWLINE') {
+                consecutiveNewlines++;
+                ctx.line++;
+                ctx.pos++;
+
+                // Double newline ends paragraph
+                if (consecutiveNewlines >= 2) {
+                    break;
+                }
+
+                // Single newline — peek at next line to see if it starts a block
+                if (this._isBlockStart(ctx)) {
+                    break;
+                }
+
+                // Continuation line — add the newline to content
+                content += '\n';
+                continue;
+            }
+
+            consecutiveNewlines = 0;
+            content += ctx.tokens[ctx.pos].value;
+            ctx.pos++;
+        }
+
+        // Trim trailing newlines from content
+        while (content.endsWith('\n')) {
+            content = content.slice(0, -1);
+        }
+
+        const node = new SyntaxNode('paragraph', content);
+        node.startLine = startLine;
+        node.endLine = ctx.line > startLine ? ctx.line - 1 : startLine;
+        return node;
+    }
+
+    // ── Lookahead helpers ───────────────────────────────────────
+
+    /**
+     * Returns the token type at pos + offset, or 'EOF'.
+     * @param {{tokens: import('./dfa-tokenizer.js').DFAToken[], pos: number}} ctx
+     * @param {number} offset
+     * @returns {string}
+     */
+    _lookType(ctx, offset) {
+        const i = ctx.pos + offset;
+        if (i >= ctx.tokens.length) return 'EOF';
+        return ctx.tokens[i].type;
+    }
+
+    /**
+     * Consumes tokens until NEWLINE or EOF and returns the collected text.
+     * The NEWLINE itself is consumed and ctx.line is incremented.
+     * @param {{tokens: import('./dfa-tokenizer.js').DFAToken[], pos: number, line: number}} ctx
+     * @returns {string}
+     */
+    _consumeToEndOfLine(ctx) {
+        let text = '';
+        while (
+            ctx.pos < ctx.tokens.length &&
+            ctx.tokens[ctx.pos].type !== 'NEWLINE' &&
+            ctx.tokens[ctx.pos].type !== 'EOF'
+        ) {
+            text += ctx.tokens[ctx.pos].value;
+            ctx.pos++;
+        }
+        // Skip the newline
+        if (ctx.pos < ctx.tokens.length && ctx.tokens[ctx.pos].type === 'NEWLINE') {
+            ctx.line++;
+            ctx.pos++;
+        }
+        return text;
+    }
+
+    /**
+     * Checks if the current position starts a block element.
+     * Used for paragraph continuation checks.
+     * @param {{tokens: import('./dfa-tokenizer.js').DFAToken[], pos: number}} ctx
+     * @returns {boolean}
+     */
+    _isBlockStart(ctx) {
+        if (ctx.pos >= ctx.tokens.length || ctx.tokens[ctx.pos].type === 'EOF') return true;
+        if (ctx.tokens[ctx.pos].type === 'NEWLINE') return true;
+
+        const t = ctx.tokens[ctx.pos].type;
+
+        // Heading
+        if (t === 'HASH') return true;
+
+        // Code fence
+        if (
+            t === 'BACKTICK' &&
+            this._lookType(ctx, 1) === 'BACKTICK' &&
+            this._lookType(ctx, 2) === 'BACKTICK'
+        )
+            return true;
+
+        // Blockquote
+        if (t === 'GT') return true;
+
+        // List items
+        if (this._isUnorderedListStart(ctx)) return true;
+        if (this._isOrderedListStart(ctx)) return true;
+
+        // Horizontal rule
+        if (this._isHorizontalRule(ctx)) return true;
+
+        // HTML block
+        if (t === 'LT' && (this._isHtmlBlockStart(ctx) || this._isHtmlImgTag(ctx))) return true;
+
+        // Table
+        if (t === 'PIPE') return true;
+
+        // Image
+        if (t === 'BANG' && this._lookType(ctx, 1) === 'LBRACKET') return true;
+
+        // Linked image
+        if (t === 'LBRACKET' && this._lookType(ctx, 1) === 'BANG') return true;
+
+        return false;
+    }
+}

--- a/src/renderer/scripts/parser/dfa-tokenizer.js
+++ b/src/renderer/scripts/parser/dfa-tokenizer.js
@@ -1,0 +1,123 @@
+/**
+ * @fileoverview Character-level tokenizer for markdown source text.
+ *
+ * Scans the input one character at a time and produces a flat token
+ * stream.  Consecutive plain-text characters are coalesced into a
+ * single TEXT token.  No regex is used anywhere.
+ */
+
+// ── Token types ─────────────────────────────────────────────────────
+
+/**
+ * @typedef {'TEXT'|'NEWLINE'|'HASH'|'SPACE'|'TAB'|'GT'|'DASH'|'STAR'
+ *   |'UNDERSCORE'|'TILDE'|'BACKTICK'|'PIPE'|'BANG'|'LBRACKET'
+ *   |'RBRACKET'|'LPAREN'|'RPAREN'|'LT'|'FSLASH'|'DIGIT'|'DOT'
+ *   |'PLUS'|'COLON'|'EOF'} DFATokenType
+ */
+
+/**
+ * @typedef {object} DFAToken
+ * @property {DFATokenType} type
+ * @property {string} value  - The raw character(s).
+ */
+
+// ── Character classification ────────────────────────────────────────
+
+/**
+ * Maps a single character to its token type.  Characters that don't
+ * have a dedicated type become part of a TEXT token.
+ *
+ * @param {string} ch
+ * @returns {DFATokenType|null}  null means "plain text"
+ */
+function charType(ch) {
+    switch (ch) {
+        case '\n':
+            return 'NEWLINE';
+        case '#':
+            return 'HASH';
+        case ' ':
+            return 'SPACE';
+        case '\t':
+            return 'TAB';
+        case '>':
+            return 'GT';
+        case '-':
+            return 'DASH';
+        case '*':
+            return 'STAR';
+        case '_':
+            return 'UNDERSCORE';
+        case '~':
+            return 'TILDE';
+        case '`':
+            return 'BACKTICK';
+        case '|':
+            return 'PIPE';
+        case '!':
+            return 'BANG';
+        case '[':
+            return 'LBRACKET';
+        case ']':
+            return 'RBRACKET';
+        case '(':
+            return 'LPAREN';
+        case ')':
+            return 'RPAREN';
+        case '<':
+            return 'LT';
+        case '/':
+            return 'FSLASH';
+        case '.':
+            return 'DOT';
+        case '+':
+            return 'PLUS';
+        case ':':
+            return 'COLON';
+        default:
+            if (ch >= '0' && ch <= '9') return 'DIGIT';
+            return null;
+    }
+}
+
+// ── Tokenizer ───────────────────────────────────────────────────────
+
+/**
+ * Tokenizes a markdown string character-by-character.
+ *
+ * @param {string} input
+ * @returns {DFAToken[]}
+ */
+export function tokenize(input) {
+    /** @type {DFAToken[]} */
+    const tokens = [];
+    let i = 0;
+    let textBuf = '';
+
+    function flushText() {
+        if (textBuf.length > 0) {
+            tokens.push({ type: 'TEXT', value: textBuf });
+            textBuf = '';
+        }
+    }
+
+    while (i < input.length) {
+        const ch = input[i];
+        const type = charType(ch);
+
+        if (type === null) {
+            // Plain text — accumulate.
+            textBuf += ch;
+        } else {
+            flushText();
+            tokens.push({ type, value: ch });
+        }
+
+        i++;
+    }
+
+    flushText();
+    tokens.push({ type: 'EOF', value: '' });
+
+    return tokens;
+}

--- a/test/fixtures/inputs.md
+++ b/test/fixtures/inputs.md
@@ -1,0 +1,59 @@
+# This is a title
+
+with some text and then a div. Content in the div should be parsed as  "this is just more markdown":
+
+<details>
+
+<summary>This is a paragraph</summary>
+
+## and this an h2
+
+better
+
+![an image](test.png)
+
+---
+
+or even better
+
+<figure>
+  <figcaption>an image</figcaption>
+  <img src="test.png" style="border: 1px solid black;">
+</figure>
+
+<graphics-element src="okay">
+  <source href="local.html">
+</graphics-element>
+
+</details>
+
+
+And then this is the main doc again.
+
+## with another heading
+
+This has _italic_ and *also italic* words.
+
+Here is **bold** text and ***bold italic*** text.
+
+And **_bold italic alt_** mixed with _**another bold italic**_ style.
+
+___
+
+A paragraph after the first rule.
+
+<graphics-element src="para">
+  <source href="para.html">
+</graphics-element>
+
+---
+
+A paragraph after the second rule.
+
+<graphics-element src="something">
+  <source href="additional.jsx">
+</graphics-element>
+
+***
+
+Final paragraph.

--- a/test/unit/parser/dfa-parser.test.js
+++ b/test/unit/parser/dfa-parser.test.js
@@ -1,0 +1,706 @@
+/**
+ * @fileoverview Unit tests for the DFA-based markdown parser.
+ *
+ * These tests verify that DFAParser produces the same SyntaxTree
+ * output as the regex-based MarkdownParser for all supported
+ * markdown constructs.
+ */
+
+import assert from 'node:assert';
+import { beforeEach, describe, it } from 'node:test';
+import { DFAParser } from '../../../src/renderer/scripts/parser/dfa-parser.js';
+import { tokenize } from '../../../src/renderer/scripts/parser/dfa-tokenizer.js';
+
+// ── Tokenizer tests ─────────────────────────────────────────────────
+
+describe('DFA Tokenizer', () => {
+    it('should tokenize an empty string to just EOF', () => {
+        const tokens = tokenize('');
+        assert.strictEqual(tokens.length, 1);
+        assert.strictEqual(tokens[0].type, 'EOF');
+    });
+
+    it('should tokenize plain text into a single TEXT token', () => {
+        const tokens = tokenize('hello');
+        assert.strictEqual(tokens.length, 2); // TEXT + EOF
+        assert.strictEqual(tokens[0].type, 'TEXT');
+        assert.strictEqual(tokens[0].value, 'hello');
+    });
+
+    it('should produce individual tokens for special characters', () => {
+        const tokens = tokenize('# ');
+        assert.strictEqual(tokens[0].type, 'HASH');
+        assert.strictEqual(tokens[1].type, 'SPACE');
+    });
+
+    it('should tokenize newlines as NEWLINE tokens', () => {
+        const tokens = tokenize('a\nb');
+        assert.strictEqual(tokens.length, 4); // TEXT NEWLINE TEXT EOF
+        assert.strictEqual(tokens[0].type, 'TEXT');
+        assert.strictEqual(tokens[0].value, 'a');
+        assert.strictEqual(tokens[1].type, 'NEWLINE');
+        assert.strictEqual(tokens[2].type, 'TEXT');
+        assert.strictEqual(tokens[2].value, 'b');
+    });
+
+    it('should tokenize digits as DIGIT tokens', () => {
+        const tokens = tokenize('1');
+        assert.strictEqual(tokens[0].type, 'DIGIT');
+        assert.strictEqual(tokens[0].value, '1');
+    });
+
+    it('should tokenize a heading line into its component tokens', () => {
+        const tokens = tokenize('## Hello');
+        const types = tokens.map((t) => t.type);
+        assert.deepStrictEqual(types, ['HASH', 'HASH', 'SPACE', 'TEXT', 'EOF']);
+    });
+
+    it('should tokenize backtick fences', () => {
+        const tokens = tokenize('```js\ncode\n```');
+        assert.strictEqual(tokens[0].type, 'BACKTICK');
+        assert.strictEqual(tokens[1].type, 'BACKTICK');
+        assert.strictEqual(tokens[2].type, 'BACKTICK');
+        assert.strictEqual(tokens[3].type, 'TEXT');
+        assert.strictEqual(tokens[3].value, 'js');
+    });
+
+    it('should tokenize HTML angle brackets', () => {
+        const tokens = tokenize('<div>');
+        assert.strictEqual(tokens[0].type, 'LT');
+        assert.strictEqual(tokens[1].type, 'TEXT');
+        assert.strictEqual(tokens[1].value, 'div');
+        assert.strictEqual(tokens[2].type, 'GT');
+    });
+
+    it('should tokenize pipes for tables', () => {
+        const tokens = tokenize('| a | b |');
+        assert.strictEqual(tokens[0].type, 'PIPE');
+    });
+});
+
+// ── Parser tests ────────────────────────────────────────────────────
+
+describe('DFAParser', () => {
+    /** @type {DFAParser} */
+    let parser;
+
+    beforeEach(() => {
+        parser = new DFAParser();
+    });
+
+    // ── Basic parsing ───────────────────────────────────────────
+
+    describe('parse', () => {
+        it('should return an empty tree for empty input', () => {
+            const tree = parser.parse('');
+            assert.strictEqual(tree.children.length, 0);
+        });
+
+        it('should parse a simple paragraph', () => {
+            const tree = parser.parse('Hello, world!');
+            assert.strictEqual(tree.children.length, 1);
+            assert.strictEqual(tree.children[0].type, 'paragraph');
+            assert.strictEqual(tree.children[0].content, 'Hello, world!');
+        });
+
+        it('should parse multiple paragraphs', () => {
+            const tree = parser.parse('First paragraph\n\nSecond paragraph');
+            assert.strictEqual(tree.children.length, 2);
+            assert.strictEqual(tree.children[0].type, 'paragraph');
+            assert.strictEqual(tree.children[0].content, 'First paragraph');
+            assert.strictEqual(tree.children[1].type, 'paragraph');
+            assert.strictEqual(tree.children[1].content, 'Second paragraph');
+        });
+    });
+
+    // ── Headings ────────────────────────────────────────────────
+
+    describe('headings', () => {
+        it('should parse heading level 1', () => {
+            const tree = parser.parse('# Heading 1');
+            assert.strictEqual(tree.children.length, 1);
+            assert.strictEqual(tree.children[0].type, 'heading1');
+            assert.strictEqual(tree.children[0].content, 'Heading 1');
+        });
+
+        it('should parse heading level 2', () => {
+            const tree = parser.parse('## Heading 2');
+            assert.strictEqual(tree.children.length, 1);
+            assert.strictEqual(tree.children[0].type, 'heading2');
+            assert.strictEqual(tree.children[0].content, 'Heading 2');
+        });
+
+        it('should parse heading level 3', () => {
+            const tree = parser.parse('### Heading 3');
+            assert.strictEqual(tree.children[0].type, 'heading3');
+        });
+
+        it('should parse heading level 4', () => {
+            const tree = parser.parse('#### Heading 4');
+            assert.strictEqual(tree.children[0].type, 'heading4');
+        });
+
+        it('should parse heading level 5', () => {
+            const tree = parser.parse('##### Heading 5');
+            assert.strictEqual(tree.children[0].type, 'heading5');
+        });
+
+        it('should parse heading level 6', () => {
+            const tree = parser.parse('###### Heading 6');
+            assert.strictEqual(tree.children[0].type, 'heading6');
+        });
+
+        it('should parse multiple headings', () => {
+            const tree = parser.parse('# First\n## Second\n### Third');
+            assert.strictEqual(tree.children.length, 3);
+            assert.strictEqual(tree.children[0].type, 'heading1');
+            assert.strictEqual(tree.children[1].type, 'heading2');
+            assert.strictEqual(tree.children[2].type, 'heading3');
+        });
+
+        it('should preserve heading content with inline formatting', () => {
+            const tree = parser.parse('## Hello **world**');
+            assert.strictEqual(tree.children[0].content, 'Hello **world**');
+        });
+    });
+
+    // ── Blockquotes ─────────────────────────────────────────────
+
+    describe('blockquotes', () => {
+        it('should parse a blockquote', () => {
+            const tree = parser.parse('> This is a quote');
+            assert.strictEqual(tree.children.length, 1);
+            assert.strictEqual(tree.children[0].type, 'blockquote');
+            assert.strictEqual(tree.children[0].content, 'This is a quote');
+        });
+
+        it('should parse multi-line blockquotes', () => {
+            const tree = parser.parse('> Line 1\n> Line 2');
+            assert.strictEqual(tree.children.length, 1);
+            assert.strictEqual(tree.children[0].type, 'blockquote');
+            assert.ok(tree.children[0].content.includes('Line 1'));
+            assert.ok(tree.children[0].content.includes('Line 2'));
+        });
+    });
+
+    // ── Code blocks ─────────────────────────────────────────────
+
+    describe('code blocks', () => {
+        it('should parse a code block', () => {
+            const tree = parser.parse('```\ncode here\n```');
+            assert.strictEqual(tree.children.length, 1);
+            assert.strictEqual(tree.children[0].type, 'code-block');
+            assert.strictEqual(tree.children[0].content, 'code here');
+        });
+
+        it('should parse a code block with language', () => {
+            const tree = parser.parse('```javascript\nconst x = 1;\n```');
+            assert.strictEqual(tree.children[0].type, 'code-block');
+            assert.strictEqual(tree.children[0].attributes.language, 'javascript');
+            assert.strictEqual(tree.children[0].content, 'const x = 1;');
+        });
+
+        it('should parse a multi-line code block', () => {
+            const tree = parser.parse('```\nline 1\nline 2\nline 3\n```');
+            assert.strictEqual(tree.children[0].type, 'code-block');
+            assert.strictEqual(tree.children[0].content, 'line 1\nline 2\nline 3');
+        });
+
+        it('should parse a code block with empty language', () => {
+            const tree = parser.parse('```\nfoo\n```');
+            assert.strictEqual(tree.children[0].attributes.language, '');
+        });
+
+        it('should preserve special characters inside code blocks', () => {
+            const tree = parser.parse('```\n# not a heading\n> not a quote\n```');
+            assert.strictEqual(tree.children.length, 1);
+            assert.strictEqual(tree.children[0].type, 'code-block');
+            assert.ok(tree.children[0].content.includes('# not a heading'));
+            assert.ok(tree.children[0].content.includes('> not a quote'));
+        });
+    });
+
+    // ── Lists ───────────────────────────────────────────────────
+
+    describe('lists', () => {
+        it('should parse an unordered list item with dash', () => {
+            const tree = parser.parse('- Item 1');
+            assert.strictEqual(tree.children.length, 1);
+            assert.strictEqual(tree.children[0].type, 'list-item');
+            assert.strictEqual(tree.children[0].content, 'Item 1');
+            assert.strictEqual(tree.children[0].attributes.ordered, false);
+        });
+
+        it('should parse an unordered list item with star', () => {
+            const tree = parser.parse('* Item 1');
+            assert.strictEqual(tree.children[0].type, 'list-item');
+            assert.strictEqual(tree.children[0].attributes.ordered, false);
+        });
+
+        it('should parse an unordered list item with plus', () => {
+            const tree = parser.parse('+ Item 1');
+            assert.strictEqual(tree.children[0].type, 'list-item');
+            assert.strictEqual(tree.children[0].attributes.ordered, false);
+        });
+
+        it('should parse an ordered list item', () => {
+            const tree = parser.parse('1. Item 1');
+            assert.strictEqual(tree.children.length, 1);
+            assert.strictEqual(tree.children[0].type, 'list-item');
+            assert.strictEqual(tree.children[0].attributes.ordered, true);
+            assert.strictEqual(tree.children[0].attributes.number, 1);
+        });
+
+        it('should parse ordered list items with different numbers', () => {
+            const tree = parser.parse('3. Third item');
+            assert.strictEqual(tree.children[0].attributes.number, 3);
+        });
+
+        it('should parse indented list items', () => {
+            const tree = parser.parse('- Item 1\n  - Nested item');
+            assert.strictEqual(tree.children.length, 2);
+            assert.strictEqual(tree.children[0].attributes.indent, 0);
+            assert.strictEqual(tree.children[1].attributes.indent, 1);
+        });
+
+        it('should parse multiple list items', () => {
+            const tree = parser.parse('- One\n- Two\n- Three');
+            assert.strictEqual(tree.children.length, 3);
+            for (const child of tree.children) {
+                assert.strictEqual(child.type, 'list-item');
+            }
+        });
+    });
+
+    // ── Horizontal rules ────────────────────────────────────────
+
+    describe('horizontal rules', () => {
+        it('should parse horizontal rule with dashes', () => {
+            const tree = parser.parse('---');
+            assert.strictEqual(tree.children.length, 1);
+            assert.strictEqual(tree.children[0].type, 'horizontal-rule');
+        });
+
+        it('should parse horizontal rule with asterisks', () => {
+            const tree = parser.parse('***');
+            assert.strictEqual(tree.children[0].type, 'horizontal-rule');
+        });
+
+        it('should parse horizontal rule with underscores', () => {
+            const tree = parser.parse('___');
+            assert.strictEqual(tree.children[0].type, 'horizontal-rule');
+        });
+
+        it('should parse horizontal rule with more than three chars', () => {
+            const tree = parser.parse('-----');
+            assert.strictEqual(tree.children[0].type, 'horizontal-rule');
+        });
+    });
+
+    // ── Tables ──────────────────────────────────────────────────
+
+    describe('tables', () => {
+        it('should parse a simple table', () => {
+            const markdown = '| A | B |\n|---|---|\n| 1 | 2 |';
+            const tree = parser.parse(markdown);
+            assert.strictEqual(tree.children.length, 1);
+            assert.strictEqual(tree.children[0].type, 'table');
+        });
+
+        it('should preserve table content exactly', () => {
+            const markdown = '| A | B |\n|---|---|\n| 1 | 2 |';
+            const tree = parser.parse(markdown);
+            assert.strictEqual(tree.children[0].content, markdown);
+        });
+
+        it('should parse a table with multiple rows', () => {
+            const markdown = '| A | B | C |\n|---|---|---|\n| 1 | 2 | 3 |\n| 4 | 5 | 6 |';
+            const tree = parser.parse(markdown);
+            assert.strictEqual(tree.children.length, 1);
+            assert.strictEqual(tree.children[0].type, 'table');
+            assert.strictEqual(tree.children[0].content, markdown);
+        });
+
+        it('should round-trip a table through toMarkdown', () => {
+            const markdown = '| A | B |\n|---|---|\n| 1 | 2 |';
+            const tree = parser.parse(markdown);
+            assert.strictEqual(tree.children[0].toMarkdown(), markdown);
+        });
+
+        it('should parse a table among other elements', () => {
+            const markdown = '# Title\n\n| A | B |\n|---|---|\n| 1 | 2 |\n\nSome text';
+            const tree = parser.parse(markdown);
+            assert.strictEqual(tree.children.length, 3);
+            assert.strictEqual(tree.children[0].type, 'heading1');
+            assert.strictEqual(tree.children[1].type, 'table');
+            assert.strictEqual(tree.children[2].type, 'paragraph');
+        });
+    });
+
+    // ── Images ──────────────────────────────────────────────────
+
+    describe('images', () => {
+        it('should parse a bare image', () => {
+            const tree = parser.parse('![alt text](image.png)');
+            assert.strictEqual(tree.children.length, 1);
+            assert.strictEqual(tree.children[0].type, 'image');
+            assert.strictEqual(tree.children[0].content, 'alt text');
+            assert.strictEqual(tree.children[0].attributes.alt, 'alt text');
+            assert.strictEqual(tree.children[0].attributes.url, 'image.png');
+            assert.strictEqual(tree.children[0].attributes.href, undefined);
+        });
+
+        it('should parse an image with empty alt text', () => {
+            const tree = parser.parse('![](photo.jpg)');
+            assert.strictEqual(tree.children.length, 1);
+            assert.strictEqual(tree.children[0].type, 'image');
+            assert.strictEqual(tree.children[0].content, '');
+            assert.strictEqual(tree.children[0].attributes.alt, '');
+            assert.strictEqual(tree.children[0].attributes.url, 'photo.jpg');
+        });
+
+        it('should parse a linked image', () => {
+            const tree = parser.parse('[![logo](logo.png)](https://example.com)');
+            assert.strictEqual(tree.children.length, 1);
+            assert.strictEqual(tree.children[0].type, 'image');
+            assert.strictEqual(tree.children[0].content, 'logo');
+            assert.strictEqual(tree.children[0].attributes.alt, 'logo');
+            assert.strictEqual(tree.children[0].attributes.url, 'logo.png');
+            assert.strictEqual(tree.children[0].attributes.href, 'https://example.com');
+        });
+
+        it('should round-trip a bare image through toMarkdown', () => {
+            const markdown = '![alt text](image.png)';
+            const tree = parser.parse(markdown);
+            assert.strictEqual(tree.children[0].toMarkdown(), markdown);
+        });
+
+        it('should round-trip a linked image through toMarkdown', () => {
+            const markdown = '[![logo](logo.png)](https://example.com)';
+            const tree = parser.parse(markdown);
+            assert.strictEqual(tree.children[0].toMarkdown(), markdown);
+        });
+
+        it('should parse an image with a full URL', () => {
+            const tree = parser.parse('![photo](https://example.com/img.jpg)');
+            assert.strictEqual(tree.children[0].type, 'image');
+            assert.strictEqual(tree.children[0].attributes.url, 'https://example.com/img.jpg');
+        });
+
+        it('should parse an image among other elements', () => {
+            const markdown = '# Title\n\n![photo](img.png)\n\nSome text';
+            const tree = parser.parse(markdown);
+            assert.strictEqual(tree.children.length, 3);
+            assert.strictEqual(tree.children[0].type, 'heading1');
+            assert.strictEqual(tree.children[1].type, 'image');
+            assert.strictEqual(tree.children[2].type, 'paragraph');
+        });
+
+        it('should parse an HTML img tag with src, alt and style', () => {
+            const tree = parser.parse('<img src="photo.png" alt="A photo" style="zoom: 80%;" />');
+            assert.strictEqual(tree.children.length, 1);
+            assert.strictEqual(tree.children[0].type, 'image');
+            assert.strictEqual(tree.children[0].attributes.url, 'photo.png');
+            assert.strictEqual(tree.children[0].attributes.alt, 'A photo');
+            assert.strictEqual(tree.children[0].attributes.style, 'zoom: 80%;');
+        });
+
+        it('should parse an HTML img tag without style', () => {
+            const tree = parser.parse('<img src="pic.jpg" alt="test" />');
+            assert.strictEqual(tree.children.length, 1);
+            assert.strictEqual(tree.children[0].type, 'image');
+            assert.strictEqual(tree.children[0].attributes.url, 'pic.jpg');
+            assert.strictEqual(tree.children[0].attributes.alt, 'test');
+            assert.strictEqual(tree.children[0].attributes.style, undefined);
+        });
+
+        it('should parse an HTML img tag without alt', () => {
+            const tree = parser.parse('<img src="pic.jpg" style="display: block;" />');
+            assert.strictEqual(tree.children[0].type, 'image');
+            assert.strictEqual(tree.children[0].attributes.url, 'pic.jpg');
+            assert.strictEqual(tree.children[0].attributes.alt, '');
+            assert.strictEqual(tree.children[0].attributes.style, 'display: block;');
+        });
+
+        it('should parse a non-self-closing HTML img tag', () => {
+            const tree = parser.parse('<img src="pic.jpg" alt="test">');
+            assert.strictEqual(tree.children[0].type, 'image');
+            assert.strictEqual(tree.children[0].attributes.url, 'pic.jpg');
+            assert.strictEqual(tree.children[0].attributes.alt, 'test');
+        });
+
+        it('should serialize an image without style as markdown syntax', () => {
+            const tree = parser.parse('<img src="pic.jpg" alt="test" />');
+            assert.strictEqual(tree.children[0].toMarkdown(), '![test](pic.jpg)');
+        });
+    });
+
+    // ── HTML blocks ─────────────────────────────────────────────
+
+    describe('html blocks', () => {
+        it('should parse a self-closed HTML block', () => {
+            const tree = parser.parse('<summary>Some text</summary>');
+            assert.strictEqual(tree.children.length, 1);
+            assert.strictEqual(tree.children[0].type, 'html-block');
+            assert.strictEqual(tree.children[0].attributes.tagName, 'summary');
+            assert.strictEqual(tree.children[0].children.length, 1);
+            assert.strictEqual(tree.children[0].children[0].type, 'paragraph');
+            assert.strictEqual(tree.children[0].children[0].content, 'Some text');
+            assert.strictEqual(tree.children[0].children[0].attributes.bareText, true);
+        });
+
+        it('should parse a multi-line HTML block', () => {
+            const tree = parser.parse('<details>\n\n## Heading\n\nSome text\n\n</details>');
+            assert.strictEqual(tree.children.length, 1);
+            assert.strictEqual(tree.children[0].type, 'html-block');
+            assert.strictEqual(tree.children[0].attributes.tagName, 'details');
+            assert.strictEqual(tree.children[0].attributes.openingTag, '<details>');
+            assert.strictEqual(tree.children[0].attributes.closingTag, '</details>');
+            assert.ok(tree.children[0].children.length >= 2);
+        });
+
+        it('should parse nested HTML blocks (details with summary)', () => {
+            const markdown =
+                '<details>\n\n<summary>Title</summary>\n\n## Heading\n\nText\n\n</details>';
+            const tree = parser.parse(markdown);
+            assert.strictEqual(tree.children.length, 1);
+            assert.strictEqual(tree.children[0].type, 'html-block');
+            assert.strictEqual(tree.children[0].attributes.tagName, 'details');
+        });
+
+        it('should recursively parse markdown inside HTML blocks', () => {
+            const tree = parser.parse('<div>\n\n# Title\n\nParagraph\n\n</div>');
+            assert.strictEqual(tree.children[0].type, 'html-block');
+            const children = tree.children[0].children;
+            assert.strictEqual(children[0].type, 'heading1');
+            assert.strictEqual(children[0].content, 'Title');
+            assert.strictEqual(children[1].type, 'paragraph');
+            assert.strictEqual(children[1].content, 'Paragraph');
+        });
+
+        it('should parse a custom element with a hyphenated tag name', () => {
+            const tree = parser.parse('<my-component>\n\nHello\n\n</my-component>');
+            assert.strictEqual(tree.children.length, 1);
+            assert.strictEqual(tree.children[0].type, 'html-block');
+            assert.strictEqual(tree.children[0].attributes.tagName, 'my-component');
+            assert.strictEqual(tree.children[0].attributes.openingTag, '<my-component>');
+            assert.strictEqual(tree.children[0].attributes.closingTag, '</my-component>');
+            assert.strictEqual(tree.children[0].children.length, 1);
+            assert.strictEqual(tree.children[0].children[0].type, 'paragraph');
+            assert.strictEqual(tree.children[0].children[0].content, 'Hello');
+        });
+
+        it('should parse a custom element with multiple hyphens', () => {
+            const tree = parser.parse('<my-cool-widget>\n\nContent\n\n</my-cool-widget>');
+            assert.strictEqual(tree.children.length, 1);
+            assert.strictEqual(tree.children[0].type, 'html-block');
+            assert.strictEqual(tree.children[0].attributes.tagName, 'my-cool-widget');
+        });
+
+        it('should parse a self-closed custom element', () => {
+            const tree = parser.parse('<app-header>Title text</app-header>');
+            assert.strictEqual(tree.children.length, 1);
+            assert.strictEqual(tree.children[0].type, 'html-block');
+            assert.strictEqual(tree.children[0].attributes.tagName, 'app-header');
+            assert.strictEqual(tree.children[0].children[0].content, 'Title text');
+            assert.strictEqual(tree.children[0].children[0].attributes.bareText, true);
+        });
+
+        it('should parse custom elements with attributes', () => {
+            const tree = parser.parse('<my-element class="test">\n\nBody\n\n</my-element>');
+            assert.strictEqual(tree.children.length, 1);
+            assert.strictEqual(tree.children[0].type, 'html-block');
+            assert.strictEqual(tree.children[0].attributes.tagName, 'my-element');
+            assert.strictEqual(tree.children[0].attributes.openingTag, '<my-element class="test">');
+        });
+
+        it('should NOT treat a bare word with no hyphen as a custom element', () => {
+            const tree = parser.parse('<notarealtag>\n\nText\n\n</notarealtag>');
+            // "notarealtag" is not in HTML_BLOCK_TAGS and has no hyphen, so
+            // it should fall through to paragraph parsing
+            assert.strictEqual(tree.children[0].type, 'paragraph');
+        });
+
+        it('should round-trip a custom element block', () => {
+            const md = '<my-component>\n\nSome content\n\n</my-component>';
+            const tree = parser.parse(md);
+            assert.strictEqual(tree.toMarkdown(), md);
+        });
+    });
+
+    // ── parseSingleLine ─────────────────────────────────────────
+
+    describe('parseSingleLine', () => {
+        it('should return null for empty input', () => {
+            assert.strictEqual(parser.parseSingleLine(''), null);
+        });
+
+        it('should parse a heading', () => {
+            const node = parser.parseSingleLine('## Title');
+            assert.ok(node);
+            assert.strictEqual(node.type, 'heading2');
+            assert.strictEqual(node.content, 'Title');
+        });
+
+        it('should parse a paragraph', () => {
+            const node = parser.parseSingleLine('Just text');
+            assert.ok(node);
+            assert.strictEqual(node.type, 'paragraph');
+            assert.strictEqual(node.content, 'Just text');
+        });
+
+        it('should parse a list item', () => {
+            const node = parser.parseSingleLine('- item');
+            assert.ok(node);
+            assert.strictEqual(node.type, 'list-item');
+            assert.strictEqual(node.content, 'item');
+        });
+
+        it('should parse a blockquote', () => {
+            const node = parser.parseSingleLine('> quote');
+            assert.ok(node);
+            assert.strictEqual(node.type, 'blockquote');
+            assert.strictEqual(node.content, 'quote');
+        });
+    });
+
+    // ── Complex documents ───────────────────────────────────────
+
+    describe('complex documents', () => {
+        it('should parse a document with mixed elements', () => {
+            const markdown = `# Title
+
+This is a paragraph.
+
+## Subtitle
+
+> A quote
+
+- List item 1
+- List item 2
+
+\`\`\`js
+code
+\`\`\``;
+            const tree = parser.parse(markdown);
+            assert.ok(tree.children.length >= 6);
+        });
+
+        it('should handle consecutive headings without blanks', () => {
+            const tree = parser.parse('# One\n## Two\n### Three');
+            assert.strictEqual(tree.children.length, 3);
+            assert.strictEqual(tree.children[0].type, 'heading1');
+            assert.strictEqual(tree.children[1].type, 'heading2');
+            assert.strictEqual(tree.children[2].type, 'heading3');
+        });
+
+        it('should handle heading then paragraph', () => {
+            const tree = parser.parse('# Title\n\nSome body text here.');
+            assert.strictEqual(tree.children.length, 2);
+            assert.strictEqual(tree.children[0].type, 'heading1');
+            assert.strictEqual(tree.children[1].type, 'paragraph');
+        });
+
+        it('should handle code block then paragraph', () => {
+            const tree = parser.parse('```\ncode\n```\n\ntext after');
+            assert.strictEqual(tree.children.length, 2);
+            assert.strictEqual(tree.children[0].type, 'code-block');
+            assert.strictEqual(tree.children[1].type, 'paragraph');
+        });
+
+        it('should handle list items then paragraph', () => {
+            const tree = parser.parse('- a\n- b\n\nA paragraph');
+            assert.strictEqual(tree.children.length, 3);
+            assert.strictEqual(tree.children[0].type, 'list-item');
+            assert.strictEqual(tree.children[1].type, 'list-item');
+            assert.strictEqual(tree.children[2].type, 'paragraph');
+        });
+
+        it('should preserve inline markdown in paragraph content', () => {
+            const tree = parser.parse('This has **bold** and *italic* text');
+            assert.strictEqual(tree.children[0].content, 'This has **bold** and *italic* text');
+        });
+
+        it('should handle the details fixture document', () => {
+            const markdown = [
+                '# This is a title',
+                '',
+                'with some text and then a div. Content in the div should be parsed as  "this is just more markdown":',
+                '',
+                '<details>',
+                '',
+                '<summary>This is a paragraph</summary>',
+                '',
+                '## and this an h2',
+                '',
+                'better',
+                '',
+                '</details>',
+                '',
+                'And then this is the main doc again.',
+                '',
+                '## with another heading',
+                '',
+                'wow',
+            ].join('\n');
+
+            const tree = parser.parse(markdown);
+            // Should have: heading, paragraph, details block, paragraph, heading, paragraph
+            assert.ok(tree.children.length >= 5);
+            assert.strictEqual(tree.children[0].type, 'heading1');
+            assert.strictEqual(tree.children[0].content, 'This is a title');
+        });
+    });
+
+    // ── Round-trip tests ────────────────────────────────────────
+
+    describe('round-trip (toMarkdown)', () => {
+        it('should round-trip a heading', () => {
+            const md = '## Hello World';
+            const tree = parser.parse(md);
+            assert.strictEqual(tree.toMarkdown(), md);
+        });
+
+        it('should round-trip a paragraph', () => {
+            const md = 'Just some text';
+            const tree = parser.parse(md);
+            assert.strictEqual(tree.toMarkdown(), md);
+        });
+
+        it('should round-trip a blockquote', () => {
+            const md = '> Quoted text';
+            const tree = parser.parse(md);
+            assert.strictEqual(tree.toMarkdown(), md);
+        });
+
+        it('should round-trip a code block', () => {
+            const md = '```js\nconst x = 1;\n```';
+            const tree = parser.parse(md);
+            assert.strictEqual(tree.toMarkdown(), md);
+        });
+
+        it('should round-trip an unordered list item', () => {
+            const md = '- Item one';
+            const tree = parser.parse(md);
+            assert.strictEqual(tree.toMarkdown(), md);
+        });
+
+        it('should round-trip an ordered list item', () => {
+            const md = '1. First item';
+            const tree = parser.parse(md);
+            assert.strictEqual(tree.toMarkdown(), md);
+        });
+
+        it('should round-trip a horizontal rule', () => {
+            const md = '---';
+            const tree = parser.parse(md);
+            assert.strictEqual(tree.toMarkdown(), md);
+        });
+
+        it('should round-trip a self-closed HTML block', () => {
+            const md = '<summary>Some text</summary>';
+            const tree = parser.parse(md);
+            assert.strictEqual(tree.toMarkdown(), md);
+        });
+    });
+});


### PR DESCRIPTION
## DFA-based tokenizer and parser (closes #63)

### What

Adds a new markdown parser built on tokenization and DFA state-machine pathing, as requested in issue #63. The existing regex-based parser is untouched.

### New files

- **`src/renderer/scripts/parser/dfa-tokenizer.js`** — Character-level tokenizer that scans input one character at a time and produces a flat token stream (TEXT, NEWLINE, HASH, SPACE, TAB, GT, DASH, STAR, UNDERSCORE, TILDE, BACKTICK, PIPE, BANG, LBRACKET, RBRACKET, LPAREN, RPAREN, LT, FSLASH, DIGIT, DOT, PLUS, COLON, EOF). Consecutive plain-text characters are coalesced into a single TEXT token. No regex anywhere.
- **`src/renderer/scripts/parser/dfa-parser.js`** — `DFAParser` class that consumes the token stream via a DFA and produces a `SyntaxTree` using the existing `SyntaxNode`/`SyntaxTree` classes. Supports: headings (h1–h6), paragraphs, fenced code blocks (with language tag), blockquotes, unordered and ordered lists, horizontal rules, markdown images, linked images, HTML `<img>` tags, HTML block elements (including nesting and recursive markdown parsing of body content), tables, and custom HTML elements with hyphenated tag names (web components like `<my-component>`).
- **`test/unit/parser/dfa-parser.test.js`** — 66 unit tests covering the tokenizer, all block types, `parseSingleLine`, complex multi-block documents, round-trip `toMarkdown()` fidelity, and custom element edge cases.
- **`scripts/parse-markdown.js`** — CLI utility for manually testing the parser: `node scripts/parse-markdown.js "# Hello"` or `node scripts/parse-markdown.js --file path/to/file.md`. Shows input, syntax tree, and round-trip output.
- **`test/fixtures/inputs.md`** — Rich fixture file exercising headings, paragraphs, nested details/summary, images, horizontal rules, figure/figcaption, custom elements (`<graphics-element>`), and inline formatting.

### Key design decisions

- **No regex**: the tokenizer classifies characters one at a time via a `charType()` function and a coalescing loop. The parser never uses regex for any matching or extraction.
- **No line splitting**: the DFA consumes NEWLINE as a token like any other; there is no `split('\n')` or line-by-line processing.
- **Reuses existing tree classes**: imports `SyntaxNode` and `SyntaxTree` from `syntax-tree.js` so output is directly compatible with the rest of the editor.
- **Custom HTML elements**: tag names like `<my-component>` tokenize as `LT TEXT("my") DASH TEXT("component") GT`. A `_peekTagName()` helper collects `TEXT (DASH TEXT)*` sequences, and `_isValidCustomElement()` validates the naming rules (must contain at least one hyphen, no leading/trailing/consecutive hyphens).

### Test results

All 286 unit tests pass. Lint (Biome + TSC) is clean.