### PR TITLE
feat: support ***bold-italic*** formatting, fix HR eating *** at EOF

### DIFF
--- a/docs/developers/architecture.md
+++ b/docs/developers/architecture.md
@@ -293,7 +293,9 @@ Key behaviors:
 
 Tokenizes inline markdown formatting within a line of text:
 - Splits text into segments of plain text and formatting delimiters
-- Handles bold, italic, strikethrough, code, links, images, subscript, superscript
+- Handles bold, italic, bold-italic (`***`), strikethrough, code, links, images, subscript, superscript
+- Treats `***` as an atomic bold-italic delimiter (single open/close token pair)
+- Treats four or more consecutive asterisks (`****`+) as plain text
 - Used by `SyntaxNode.toBareText()` and `SyntaxHighlighter` for inline parsing
 
 ### BaseModal

--- a/src/renderer/scripts/editor/renderers/focused-renderer.js
+++ b/src/renderer/scripts/editor/renderers/focused-renderer.js
@@ -740,6 +740,15 @@ export class FocusedRenderer {
                     container.appendChild(document.createTextNode(''));
                     break;
                 }
+                case 'bold-italic': {
+                    const strong = document.createElement('strong');
+                    const em = document.createElement('em');
+                    this.appendSegments(seg.children ?? [], em);
+                    strong.appendChild(em);
+                    container.appendChild(strong);
+                    container.appendChild(document.createTextNode(''));
+                    break;
+                }
                 case 'italic': {
                     const em = document.createElement('em');
                     this.appendSegments(seg.children ?? [], em);

--- a/src/renderer/scripts/parser/dfa-parser.js
+++ b/src/renderer/scripts/parser/dfa-parser.js
@@ -513,15 +513,11 @@ export class DFAParser {
         }
         if (count < 3) return false;
 
-        // Only spaces allowed after the run, then NEWLINE or EOF
+        // Only spaces allowed after the run, then NEWLINE (not EOF)
         while (i < ctx.tokens.length && ctx.tokens[i].type === 'SPACE') {
             i++;
         }
-        return (
-            i >= ctx.tokens.length ||
-            ctx.tokens[i].type === 'NEWLINE' ||
-            ctx.tokens[i].type === 'EOF'
-        );
+        return i < ctx.tokens.length && ctx.tokens[i].type === 'NEWLINE';
     }
 
     /**

--- a/test/unit/parser/dfa-parser.test.js
+++ b/test/unit/parser/dfa-parser.test.js
@@ -276,23 +276,23 @@ describe('DFAParser', () => {
 
     describe('horizontal rules', () => {
         it('should parse horizontal rule with dashes', () => {
-            const tree = parser.parse('---');
+            const tree = parser.parse('---\n');
             assert.strictEqual(tree.children.length, 1);
             assert.strictEqual(tree.children[0].type, 'horizontal-rule');
         });
 
         it('should parse horizontal rule with asterisks', () => {
-            const tree = parser.parse('***');
+            const tree = parser.parse('***\n');
             assert.strictEqual(tree.children[0].type, 'horizontal-rule');
         });
 
         it('should parse horizontal rule with underscores', () => {
-            const tree = parser.parse('___');
+            const tree = parser.parse('___\n');
             assert.strictEqual(tree.children[0].type, 'horizontal-rule');
         });
 
         it('should parse horizontal rule with more than three chars', () => {
-            const tree = parser.parse('-----');
+            const tree = parser.parse('-----\n');
             assert.strictEqual(tree.children[0].type, 'horizontal-rule');
         });
     });

--- a/test/unit/parser/inline-tokenizer.test.js
+++ b/test/unit/parser/inline-tokenizer.test.js
@@ -36,6 +36,33 @@ describe('tokenizeInline', () => {
         assert.equal(tokens[3].type, 'italic-close');
     });
 
+    it('tokenizes ***bold+italic*** as a single bold-italic open/close pair', () => {
+        const tokens = tokenizeInline('a ***b*** c');
+        assert.equal(tokens.length, 5);
+        assert.equal(tokens[0].type, 'text');
+        assert.equal(tokens[1].type, 'bold-italic-open');
+        assert.equal(tokens[1].raw, '***');
+        assert.equal(tokens[2].type, 'text');
+        assert.equal(tokens[2].raw, 'b');
+        assert.equal(tokens[3].type, 'bold-italic-close');
+        assert.equal(tokens[3].raw, '***');
+        assert.equal(tokens[4].type, 'text');
+    });
+
+    it('treats **** (four or more asterisks) as plain text', () => {
+        const tokens = tokenizeInline('a **** b');
+        assert.equal(tokens.length, 1);
+        assert.equal(tokens[0].type, 'text');
+        assert.equal(tokens[0].raw, 'a **** b');
+    });
+
+    it('treats ***** (five asterisks) as plain text', () => {
+        const tokens = tokenizeInline('hello ***** world');
+        assert.equal(tokens.length, 1);
+        assert.equal(tokens[0].type, 'text');
+        assert.equal(tokens[0].raw, 'hello ***** world');
+    });
+
     it('tokenizes ~~strikethrough~~ markers', () => {
         const tokens = tokenizeInline('a ~~b~~ c');
         assert.equal(tokens[1].type, 'strikethrough-open');
@@ -200,6 +227,26 @@ describe('buildInlineTree', () => {
         assert.equal(tree[0].children.length, 2);
         assert.equal(tree[0].children[0].type, 'text');
         assert.equal(tree[0].children[1].type, 'bold');
+    });
+
+    it('builds bold-italic segment from ***word***', () => {
+        const tokens = tokenizeInline('test ***word*** end');
+        const tree = buildInlineTree(tokens);
+        assert.equal(tree.length, 3);
+        assert.equal(tree[0].type, 'text');
+        assert.equal(tree[0].text, 'test ');
+        assert.equal(tree[1].type, 'bold-italic');
+        assert.equal(tree[1].children.length, 1);
+        assert.equal(tree[1].children[0].text, 'word');
+        assert.equal(tree[2].type, 'text');
+    });
+
+    it('treats **** as plain text in tree', () => {
+        const tokens = tokenizeInline('test **** end');
+        const tree = buildInlineTree(tokens);
+        assert.equal(tree.length, 1);
+        assert.equal(tree[0].type, 'text');
+        assert.equal(tree[0].text, 'test **** end');
     });
 
     it('builds an image segment from an image token', () => {


### PR DESCRIPTION
## Summary

`***word***` was not rendering as bold-italic. Instead, the content would disappear entirely when typed at the end of a line, or render incorrectly with raw asterisks visible.

## Root cause

Two independent bugs:

1. **DFA parser's `_isHorizontalRule` treated EOF as equivalent to NEWLINE.** When `***` was typed at the end of a line (i.e. at EOF), the DFA parser recognized it as a horizontal rule and consumed the entire paragraph content. The `***` delimiter and everything before it on that line was destroyed during reparse. A horizontal rule requires `***\n` — EOF is not a newline.

2. **The inline tokenizer had no concept of `***` as a single delimiter.** It only knew about `*` (italic) and `**` (bold) separately. There was no way to express bold-italic as a combined formatting.

## Changes

### `dfa-parser.js`
- `_isHorizontalRule`: changed the termination check from `type === 'NEWLINE' || type === 'EOF'` to require an actual `NEWLINE` token. EOF no longer qualifies as a valid HR terminator.

### `inline-tokenizer.js`
- Added `bold-italic-open` / `bold-italic-close` as an atomic token type — `***` is a single delimiter, not a combination of `*` + `**`.
- Added a handler for four or more consecutive asterisks (`****`+) that treats them as plain text.
- Added guards on the `*` and `**` handlers to skip when an unclosed `bold-italic-open` token exists, preventing nested openers inside a `***...***` span.
- Updated `CLOSE_TYPE_FOR`, `SEGMENT_TYPE_FOR`, `buildInlineTree`, and `findMatchedTokenIndices` to support the new token type.

### `focused-renderer.js`
- Added `bold-italic` case in `appendSegments` — renders `<strong><em>children</em></strong>`.

### `architecture.md`
- Updated InlineTokenizer section to document `***` and `****`+ handling.

### Tests
- 5 new unit tests in `inline-tokenizer.test.js` (token output and tree building for `***` and `****`).
- 4 new integration tests in `cursor-typing-delimiters.spec.js` (typing `***word***` and `****`).
- 4 updated HR unit tests in `dfa-parser.test.js` (inputs now include required trailing `\n`).

All 300 unit tests and 246 integration tests pass.