### PR TITLE
Model inline formatting as nested SyntaxNode children

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,22 @@
 # Pomax's Markdown Editor
 
-A "professional" markdown editor built with Electron, featuring a syntactic tree-based document model for fast editing of large documents.
+A GitHub-flavoured markdown editor built using the web stack, running in Electron, featuring a syntactic tree-based document model for fast editing of large documents (e.g. 50k+ work documents like https://pomax.github.io/are-we-flying).
 
 ![A screenshot of the editor](./screenshot-1.png)
 
-## Download
+## Current version: v1.7.0
 
-Pre-built standalone executables for Windows, macOS, and Linux are available on the [Releases](https://github.com/Pomax/Pomax-s-Markdown-Editor/releases/latest) page. No installation or Node.js required — just download and run.
+See the [release notes](./RELEASE_NOTES.md) for what's new in this version.
+
+### Downloads
+
+This editor is released as a standalone, installer-free executable for Windows, MacOS, and Linux. Current download links:
+
+- Windows exe: [Markdown.Editor.1.7.0.exe](https://github.com/Pomax/Pomax-s-Markdown-Editor/releases/download/v1.7.0/Markdown.Editor.1.7.0.exe)
+- MacOS App (zipped): [Markdown.Editor-1.7.0-arm64-mac.zip](https://github.com/Pomax/Pomax-s-Markdown-Editor/releases/download/v1.7.0/Markdown.Editor-1.7.0-arm64-mac.zip)
+- Linux AppImage: [Markdown.Editor-1.7.0.AppImage](https://github.com/Pomax/Pomax-s-Markdown-Editor/releases/download/v1.7.0/Markdown.Editor-1.7.0.AppImage)
+
+Previous versions can be found over on the [Releases](https://github.com/Pomax/Pomax-s-Markdown-Editor/releases/latest) page.
 
 ## Eww, Electron?
 
@@ -14,47 +24,38 @@ Sorry, did you not have 8+GB if RAM and 1TB+ of disk space? Stop pretending you 
 
 ## Fine... so what is this?
 
-This is a project that was product managed by a real human (me, Pomax!) but written by Claude Opus 4.5/4.6, which is the first LLM that seems to be alright at programming. It was written in a way to be accessible by new devs as well as other AI agents, so it should be pretty damn easy to add new functionality. If using an AI, tell it to first read `docs/developers/ai-agent-notes.md` and the other `docs/developers` files, and then get to work.
+This is part experiment, part necessary tooling: I needed a markdown editor that can actually work with huge documents without either being "split view", or needing installers that require admin rights while secretly owned by a Chinese company. I also wanted to see if Opus 4.5/4.6 was up to the task of doing normal software development. So this is a public domain licensed (i.e. no license claims whatsoever) piece of open source software that was product managed by me, and written by Opus. 
 
-PRs are of course welcome, provided it's preceded by you filing an issue to explain what it is you want to do, why you think that should be part of the codebase, and how you're going to do that: either by yourself, or by using an AI. Note that if you want to use an AI agent, the only one I'm going to even consider fixes from is Opus 4.6 - I've watched ChatGPT and Qwen literally destroy the good work Opus has produced and replace it with completely bullshit nonsense.
+Also note that this project was not "vibe coded": the dev work uses branches, unit tests, integration tests, as well as up to date docs and requirements with acceptance criteria. All of this is standard dev practice, and no work that fails testing gets through. Also, plans get shot down plenty because they make assumptions that don't hold up, or would make it harder to work on the code. The point here is to have a codebase that is accessible to both AI agents as well as real human beings if they want to help fix something, or land a new feature.
 
-No on has time for that.
+If you intend to use an agent, every prompt should be preceded by `(re)read the ai-agent-notes first, and then ...` because agents can't pin instructions. They _will_ just remove that information from their context for no reason, at any time.
+
+## So it's AI slop, got it.
+
+If you think a fully featured markdown editor with a codebase that you can actually read, with design and architecture docs that accurately reflect that codebase, and over 500 tests is slop, then it might be time to start forming your own opinions again instead of just parroting others. These tools need a lot of work to make sure they do the right thing, and plenty of dev work went into making an editor that _I_ would use, and my requirements are much more demanding than most because code that can't be maintained and explained is code that shouldn't exist.
 
 ## Features
 
 - **Fast Editing**: Documents are parsed into a syntactic tree structure, enabling efficient editing regardless of document size
-
 - **Dual View Modes**:
-
   - **Source View**: Shows literal markdown with syntax highlighting
-
   - **Focused Writing**: WYSIWYG-style editing that hides syntax unless focused
-
 - **WYSIWYG Toolbar**: Context-aware formatting toolbar that adapts to the current element
-
 - **Table of Contents**: Resizable sidebar with live-updating headings navigation (left or right)
-
 - **Image Support**: Insert, edit, rename, and drag & drop images; gather images into the document folder
-
 - **Table Support**: Insert and edit tables via a modal dialog
-
 - **Search**: Find text in the editor with plain text or regex, case-sensitive toggle, and match navigation (`Ctrl+F`)
-
 - **Preferences**: Configurable page margins, page width, page colors, default view mode, and TOC settings
-
 - **Word Count**: Total word count and word count excluding code (File → Word Count)
-
 - **Multi-file Editing**: Open multiple documents in tabs; tab bar at bottom, switchable via View menu
-
 - **Unlimited Undo/Redo**: Complete edit history with no limit
-
 - **Scripting API**: Full IPC-based API for external automation
-
 - **A4 Page Layout**: Document-centric design with configurable page dimensions
-
 - **Debug Mode**: Help → Debug opens DevTools and enables context menus
 
-## Getting Started
+## Running from source
+
+You can obviously just run this project from source if you want. It's just a web stack project wrapped by Electron.
 
 ### Prerequisites
 
@@ -65,6 +66,8 @@ No on has time for that.
 ```sh
 npm install
 ```
+
+You will also need to run a one-time `npx playwright install firefox --with-deps` to ensure you can run the integration tests.
 
 ### Running the Application
 
@@ -109,61 +112,27 @@ npm start
 │   └── integration/    # Playwright integration tests
 │
 ├── docs/
-│   ├── api/            # API documentation
+│   ├── api/            # API documentation for IPC interaction
 │   └── developers/     # Developer guides
 │
 └── scripts/            # Build utilities
 ```
 
-## Usage
-
-### File Operations
-
-- **New**: `Ctrl+N` - Create a new document
-
-- **Load**: `Ctrl+O` - Open a markdown file
-
-- **Save**: `Ctrl+S` - Save the current document
-
-- **Save As**: `Ctrl+Shift+S` - Save with a new filename
-
-- **Close**: `Ctrl+W` - Close the current document
-
-### View Modes
-
-- **Source View**: `Ctrl+1` - Show raw markdown with syntax highlighting
-
-- **Focused Writing**: `Ctrl+2` - WYSIWYG mode with hidden syntax
-
-### Formatting Shortcuts
-
-- **Bold**: `Ctrl+B`
-
-- **Italic**: `Ctrl+I`
-
-- **Link**: `Ctrl+K`
-
-- **Inline Code**: `Ctrl+\``
-
-- **Find**: `Ctrl+F`
-
-- **Heading 1-6**: `Ctrl+Alt+1` through `Ctrl+Alt+6`
-
-- **Paragraph**: `Ctrl+Alt+0`
-
-- **Blockquote**: `Ctrl+Shift+Q`
-
-- **Code Block**: `Ctrl+Shift+C`
-
-### Edit Operations
-
-- **Undo**: `Ctrl+Z`
-
-- **Redo**: `Ctrl+Y` or `Ctrl+Shift+Z`
-
 ## Testing
 
+You run the full test suite using `npm test`. Nice and obvious. This will run linting, formatting, consistency testing, unit testing, and integration testing.
+
+### Linting
+
+The general linting task performs both linting and formatting using Biome, and consistency testing using the typescript transpiler set to JS with `--no-emit` so that it performs analysis only.
+
+```sh
+npm run lint
+```
+
 ### Unit Tests
+
+Unit tests use Node's built in testing framework, and can be run on their own using:
 
 ```sh
 npm run test:unit
@@ -171,26 +140,16 @@ npm run test:unit
 
 ### Integration Tests
 
+Integration testing uses Playwright with Firefox, and can be run on their own using:
+
 ```sh
 npm run test:integration
 ```
 
-## Code Quality
-
-### Linting, Formatting, and Type Checking
-
-All code quality checks are run together:
+To run specific individual spec files, use:
 
 ```sh
-npm run lint        # Runs lint:fix + lint:format + lint:typing
-```
-
-Individual steps:
-
-```sh
-npm run lint:fix    # Auto-fix lint issues (Biome)
-npm run lint:format # Auto-format code (Biome)
-npm run lint:typing # Type check via tsc (JSDoc annotations)
+npm run test:integration -- test/integration/your.file.spec.js
 ```
 
 ## Building Executables
@@ -201,17 +160,9 @@ To build a standalone executable for the current platform:
 npm run dist
 ```
 
-Or target a specific platform:
-
-```sh
-npm run dist:win    # Windows portable .exe
-npm run dist:mac    # macOS .zip
-npm run dist:linux  # Linux AppImage
-```
-
 Build output goes to the `dist/` directory.
 
-Automated builds use a GitHub Actions workflow that builds all three platforms on every push to `main` and publishing them as a [GitHub Releases](https://github.com/Pomax/Pomax-s-Markdown-Editor/releases/latest).
+Note that this tasks primarily exists for automated builds using a GitHub Actions workflow that builds all three platforms on every push to `main` that bumps up the project version in `package.json`.
 
 ## API Documentation
 
@@ -226,42 +177,12 @@ const result = await ipcRenderer.invoke('api:execute', 'document.setContent', {
 });
 ```
 
-## Developer Documentation
+# Developer Documentation
 
 - [Getting Started](docs/developers/getting-started.md)
-
 - [Architecture](docs/developers/architecture.md)
-
 - [Design](docs/developers/design.md)
-
-## Technology Stack
-
-- **Electron**: Application framework
-
-- **JavaScript**: ES Modules with JSDoc type annotations
-
-- **HTML/CSS**: UI rendering
-
-- **Biome**: Linting and code formatting
-
-- **TypeScript**: Type checking (with `--allowJs --noEmit`)
-
-- **Node.js Test Runner**: Unit testing
-
-- **Playwright**: Integration testing (Firefox)
-
-## Design Principles
-
-1. **Separation of Concerns**: Each class has a single responsibility
-
-2. **One Class Per File**: All classes are in their own files
-
-3. **No Nested Functions**: Functions are not declared inside other functions
-
-4. **No Inline Callbacks**: Functions are not declared inline as arguments
-
-5. **Type Safety via JSDoc**: Comprehensive type annotations
 
 ## License
 
-Public Domain
+I didn't write this code, and AI can't be trusted, so this project is Public Domain. Literally do with it what you want, I'm only losing money on this, not making any.

--- a/docs/developers/ai-agent-notes.md
+++ b/docs/developers/ai-agent-notes.md
@@ -155,6 +155,12 @@ pseudo-selectors (`:has()`, `:not()`, `:scope >`) to be precise.
     added, or removed. Event handlers on untouched elements survive.
 - Most editing operations use the incremental path.
 
+### Inline children model
+
+Block-level nodes that contain inline formatting (`paragraph`, `heading1`–`heading6`, `blockquote`, `list-item`) automatically build inline child `SyntaxNode` instances when their `content` is set. The `content` property is a getter/setter — setting it triggers `buildInlineChildren()` which tokenizes the raw markdown and converts the segments into a tree of inline nodes (types: `text`, `inline-code`, `inline-image`, `bold`, `italic`, `bold-italic`, `strikethrough`, `link`, plus HTML inline tags like `sub`/`sup`).
+
+These inline children are for **introspection only** (e.g. detecting which formatting is active at a cursor offset). Editing operations work on the parent block node's raw `content` string — never on the inline children directly. Traversal methods like `findDeepestNodeAtPosition()` do not descend into inline children.
+
 ### `data-node-id` scoping
 
 Every rendered block element in the editor gets a `data-node-id` attribute

--- a/issue.md
+++ b/issue.md
@@ -1,0 +1,32 @@
+The current `SyntaxTree` only models block-level structure. A paragraph containing `**bold**` text is stored as a flat `SyntaxNode('paragraph', 'Some **bold** text')` — inline formatting is not represented as child nodes.
+
+The inline tokenizer already produces a nested tree structure via `buildInlineTree()`, but this is computed on-the-fly for rendering and discarded — never stored in the syntax tree itself.
+
+This means there's no way to ask "what node is the cursor in?" and get back a bold/italic/link/etc. node. Features that need to know what inline formatting is active at the cursor position (e.g. #48 — toolbar active states) have no tree structure to walk.
+
+## What needs to change
+
+All nodes that allow for marked up content should model that content as real syntax tree nodes. For example, `Some **bold** text` should produce:
+
+```
+paragraph
+  ├── text("Some ")
+  ├── bold
+  │     └── text("bold")
+  └── text(" text")
+```
+
+And `Some **bold *and* italic** text` should produce:
+
+```
+paragraph
+  ├── text("Some ")
+  ├── bold
+  │     ├── text("bold ")
+  │     ├── italic
+  │     │      └── text("and")
+  │     └── text(" italic")
+  └── text(" text")
+```
+
+The `treeCursor` should then point to the leaf node (e.g. the `text("bold")` inside `bold`), and walking up via `.parent` reveals enclosing formats.

--- a/scripts/parse-markdown.js
+++ b/scripts/parse-markdown.js
@@ -45,9 +45,14 @@ const tree = parser.parse(input);
 function printNode(/** @type {any} */ node, /** @type {string} */ indent) {
     const attrs =
         Object.keys(node.attributes).length > 0 ? ` ${JSON.stringify(node.attributes)}` : '';
-    const content = node.content
-        ? ` "${node.content.length > 60 ? `${node.content.slice(0, 60)}...` : node.content}"`
-        : '';
+    // Skip content on the parent line when inline children already represent it
+    const hasInlineChildren =
+        node.children.length > 0 &&
+        node.children.some((/** @type {any} */ c) => c.type !== 'html-block');
+    const content =
+        node.content && !hasInlineChildren
+            ? ` "${node.content.length > 60 ? `${node.content.slice(0, 60)}...` : node.content}"`
+            : '';
     console.log(`${indent}${node.type}${content}${attrs}  [L${node.startLine}-${node.endLine}]`);
     for (const child of node.children) {
         printNode(child, `${indent}  `);

--- a/src/main/main.js
+++ b/src/main/main.js
@@ -449,9 +449,7 @@ app.on('window-all-closed', () => {
     if (settingsManager) {
         settingsManager.close();
     }
-    if (process.platform !== 'darwin') {
-        app.quit();
-    }
+    app.quit();
 });
 
 // Run with unlimited memory

--- a/src/renderer/scripts/app.js
+++ b/src/renderer/scripts/app.js
@@ -108,8 +108,9 @@ class App {
         this.editor = new Editor(editorContainer);
         await this.editor.initialize();
 
-        // Initialize page resize handles (focused mode only)
-        initPageResizeHandles(editorContainer);
+        // Initialize page resize handles (focused mode only).
+        // Store the retarget function so tab switches can update the handles.
+        this._retargetResizeHandles = initPageResizeHandles(editorContainer) ?? null;
 
         // Initialize toolbar
         this.toolbar = new Toolbar(toolbarContainer, this.editor);
@@ -378,6 +379,11 @@ class App {
             this.editor.swapContainer(targetContainer);
             targetContainer.style.display = '';
 
+            // Re-target resize handles to the new container
+            if (this._retargetResizeHandles) {
+                this._retargetResizeHandles(targetContainer);
+            }
+
             // Restore editor state
             if (state) {
                 this.editor.currentFilePath = state.filePath;
@@ -610,6 +616,11 @@ class App {
         this.editor.swapContainer(newContainer);
         this._tabContainers.set(tabId, newContainer);
 
+        // Re-target resize handles to the new container
+        if (this._retargetResizeHandles) {
+            this._retargetResizeHandles(newContainer);
+        }
+
         // Load the new content into the editor
         this.editor.currentFilePath = filePath;
         this.editor.loadMarkdown(content);
@@ -723,6 +734,12 @@ class App {
             }
             this.editor.swapContainer(newContainer);
             this._tabContainers.set(newId, newContainer);
+
+            // Re-target resize handles to the new container
+            if (this._retargetResizeHandles) {
+                this._retargetResizeHandles(newContainer);
+            }
+
             this.editor.reset();
         } else if (wasActive && this.tabBar.activeTabId) {
             // removeTab already picked a new active tab; restore its state

--- a/src/renderer/scripts/editor/range-operations.js
+++ b/src/renderer/scripts/editor/range-operations.js
@@ -293,7 +293,10 @@ export class RangeOperations {
      */
     _firstLeaf(node) {
         let current = node;
-        while (current.children.length > 0) {
+        // Only descend into block-level children (html-block containers).
+        // Inline children (text, bold, etc.) are not rendered as separate
+        // DOM elements with data-node-id, so we must stop at block nodes.
+        while (current.type === 'html-block' && current.children.length > 0) {
             current = current.children[0];
         }
         return current;
@@ -306,7 +309,7 @@ export class RangeOperations {
      */
     _lastLeaf(node) {
         let current = node;
-        while (current.children.length > 0) {
+        while (current.type === 'html-block' && current.children.length > 0) {
             current = current.children[current.children.length - 1];
         }
         return current;

--- a/test/unit/parser/syntax-tree.test.js
+++ b/test/unit/parser/syntax-tree.test.js
@@ -20,8 +20,15 @@ describe('SyntaxNode', () => {
             assert.notStrictEqual(node1.id, node2.id);
         });
 
-        it('should initialize with empty children array', () => {
+        it('should build inline children for inline-containing types', () => {
             const node = new SyntaxNode('paragraph', 'Hello');
+            assert.strictEqual(node.children.length, 1);
+            assert.strictEqual(node.children[0].type, 'text');
+            assert.strictEqual(node.children[0].content, 'Hello');
+        });
+
+        it('should initialize with empty children for non-inline types', () => {
+            const node = new SyntaxNode('code-block', 'console.log()');
             assert.deepStrictEqual(node.children, []);
         });
     });
@@ -234,12 +241,13 @@ describe('SyntaxTree', () => {
     });
 
     describe('getNodeCount', () => {
-        it('should count all nodes', () => {
+        it('should count all nodes including inline children', () => {
             tree.appendChild(new SyntaxNode('heading1', 'Title'));
             tree.appendChild(new SyntaxNode('paragraph', 'Content'));
             tree.appendChild(new SyntaxNode('paragraph', 'More'));
 
-            assert.strictEqual(tree.getNodeCount(), 3);
+            // 3 block nodes + 3 inline text children = 6
+            assert.strictEqual(tree.getNodeCount(), 6);
         });
     });
 


### PR DESCRIPTION
Closes #72

### Problem

The `SyntaxTree` only modeled block-level structure. Inline formatting (bold, italic, links, etc.) lived as raw markdown strings in each node's `.content` field with no structured representation. This made it impossible to answer questions like "what formatting is active at cursor offset X?" without re-tokenizing on every query.

### Changes

**Inline children model (`syntax-tree.js`)**
- `content` is now a getter/setter backed by `_content`. Setting it on inline-containing node types (paragraph, heading1–6, blockquote, list-item) automatically calls `buildInlineChildren()`.
- `buildInlineChildren()` tokenizes the raw markdown via `InlineTokenizer` and converts the segment tree into child `SyntaxNode` instances with types: `text`, `inline-code`, `inline-image`, `bold`, `italic`, `bold-italic`, `strikethrough`, `link`, and HTML inline tags (`sub`, `sup`, etc.).
- `toBareText()` for inline-containing types now walks the inline children tree instead of re-tokenizing.
- `clone()` clears auto-built inline children before cloning to avoid duplication.
- `findDeepestNodeAtPosition()` does not descend into inline children — they are for introspection, not cursor navigation.
- `changeNodeType()` rebuilds or clears inline children when transitioning between inline/non-inline types.

**Traversal guard (`range-operations.js`)**
- `_firstLeaf` / `_lastLeaf` now only descend into `html-block` children, not inline children, preventing cursor operations from landing on inline nodes.

**macOS quit behavior (`main.js`)**
- Removed the `process.platform !== 'darwin'` guard in `window-all-closed` so Cmd+Q fully terminates the app instead of leaving it running in the dock.

**Docs**
- Updated `architecture.md` with inline children model section and updated `InlineTokenizer` description.
- Updated `ai-agent-notes.md` with inline children model section.

### Testing
- 283/283 unit tests pass
- 246/246 integration + full suite tests pass
- Manual testing confirmed normal editing, search, undo/redo, and Cmd+Q all work correctly