### PR TITLE
feat: true inline cursor, toolbar active states, sub/sup toggle fix

### DIFF
--- a/src/renderer/scripts/editor/edit-operations.js
+++ b/src/renderer/scripts/editor/edit-operations.js
@@ -54,7 +54,7 @@ export class EditOperations {
      *     The result object from `deleteSelectedRange()`, mutated in place.
      */
     _cleanupEmptyNodeAfterDelete(result) {
-        const node = this.editor.getCurrentNode();
+        const node = this.editor.getCurrentBlockNode();
         if (!node || !this.editor.syntaxTree) return;
 
         // Only remove types in the extensible set.
@@ -144,7 +144,7 @@ export class EditOperations {
             }
         }
 
-        const node = this.editor.getCurrentNode();
+        const node = this.editor.getCurrentBlockNode();
         if (!node || !this.editor.syntaxTree || !this.editor.syntaxTree.treeCursor) return;
 
         // When the cursor is on an html-block tag line (source view), edit
@@ -351,7 +351,7 @@ export class EditOperations {
             }
         }
 
-        const node = this.editor.getCurrentNode();
+        const node = this.editor.getCurrentBlockNode();
         if (!node || !this.editor.syntaxTree || !this.editor.syntaxTree.treeCursor) return;
 
         // When the cursor is on an html-block tag line (source view), edit
@@ -545,7 +545,7 @@ export class EditOperations {
             }
         }
 
-        const node = this.editor.getCurrentNode();
+        const node = this.editor.getCurrentBlockNode();
         if (!node || !this.editor.syntaxTree || !this.editor.syntaxTree.treeCursor) return;
 
         // When the cursor is on an html-block tag line (source view), edit
@@ -712,7 +712,7 @@ export class EditOperations {
             }
         }
 
-        const node = this.editor.getCurrentNode();
+        const node = this.editor.getCurrentBlockNode();
         if (!node || !this.editor.syntaxTree || !this.editor.syntaxTree.treeCursor) return;
 
         // html-block tag lines and containers are not splittable.

--- a/src/renderer/scripts/editor/image-helper.js
+++ b/src/renderer/scripts/editor/image-helper.js
@@ -88,7 +88,7 @@ export class ImageHelper {
         if (!this.editor.syntaxTree) return;
 
         const before = this.editor.syntaxTree.toMarkdown();
-        const currentNode = this.editor.getCurrentNode();
+        const currentNode = this.editor.getCurrentBlockNode();
         let renderHints;
 
         if (currentNode?.type === 'image') {
@@ -194,7 +194,7 @@ export class ImageHelper {
 
         // Update the node directly — after the modal closes the cursor
         // may have moved, so we cannot rely on insertOrUpdateImage which
-        // reads getCurrentNode().
+        // reads getCurrentBlockNode().
         if (!this.editor.syntaxTree) return;
         const before = this.editor.syntaxTree.toMarkdown();
         node.content = result.alt;

--- a/src/renderer/scripts/editor/input-handler.js
+++ b/src/renderer/scripts/editor/input-handler.js
@@ -134,7 +134,7 @@ export class InputHandler {
         // ── Tab / Shift+Tab inside a table ──
         if (event.key === 'Tab' && this.editor.viewMode === 'focused') {
             this.editor.syncCursorFromDOM();
-            const node = this.editor.getCurrentNode();
+            const node = this.editor.getCurrentBlockNode();
             if (
                 node?.type === 'table' &&
                 this.editor.syntaxTree?.treeCursor?.cellRow !== undefined

--- a/src/renderer/scripts/editor/range-operations.js
+++ b/src/renderer/scripts/editor/range-operations.js
@@ -147,7 +147,7 @@ export class RangeOperations {
      */
     handleSelectAll() {
         this.editor.syncCursorFromDOM();
-        const node = this.editor.getCurrentNode();
+        const node = this.editor.getCurrentBlockNode();
         if (!node) return;
 
         this._selectAllLevel++;

--- a/src/renderer/scripts/editor/table-manager.js
+++ b/src/renderer/scripts/editor/table-manager.js
@@ -238,7 +238,7 @@ export class TableManager {
      * @param {boolean} shiftKey - True for Shift+Tab (move backward)
      */
     handleTableTab(shiftKey) {
-        const node = this.editor.getCurrentNode();
+        const node = this.editor.getCurrentBlockNode();
         if (
             !node ||
             !this.editor.syntaxTree ||

--- a/test/fixtures/toolbar-active.md
+++ b/test/fixtures/toolbar-active.md
@@ -1,0 +1,11 @@
+This is **bold text** here.
+
+This is *italic text* here.
+
+This is ***bold italic*** here.
+
+This is ~~struck~~ here.
+
+This is `code` here.
+
+Plain paragraph.

--- a/test/integration/toolbar-active.spec.js
+++ b/test/integration/toolbar-active.spec.js
@@ -1,0 +1,188 @@
+/**
+ * @fileoverview Integration tests for toolbar active states.
+ *
+ * Verifies that when the cursor is placed inside inline formatting
+ * (bold, italic, strikethrough, inline code, bold-italic), the
+ * corresponding toolbar buttons show the `.active` class.
+ *
+ * Also verifies that block-level buttons (heading, paragraph, etc.)
+ * reflect the block type even when the cursor is inside inline
+ * formatting within that block.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { expect, test } from '@playwright/test';
+import {
+    clickInEditor,
+    launchApp,
+    loadContent,
+    projectRoot,
+    setFocusedView,
+} from './test-utils.js';
+
+const fixturePath = path.join(projectRoot, 'test', 'fixtures', 'toolbar-active.md');
+const fixtureContent = fs.readFileSync(fixturePath, 'utf-8');
+
+/** @type {import('@playwright/test').ElectronApplication} */
+let electronApp;
+
+/** @type {import('@playwright/test').Page} */
+let page;
+
+test.beforeAll(async () => {
+    ({ electronApp, page } = await launchApp());
+});
+
+test.afterAll(async () => {
+    await electronApp.close();
+});
+
+/**
+ * Clicks inside a specific inline element on a given line.
+ * Uses real mouse coordinates so the full event chain fires.
+ *
+ * @param {import('@playwright/test').Page} pg
+ * @param {number} lineIndex - 0-based index of the .md-line
+ * @param {string} selector - CSS selector for the inline element within the line
+ */
+async function clickInlineElement(pg, lineIndex, selector) {
+    const line = pg.locator('#editor .md-line').nth(lineIndex);
+    // Click the line first to make it the focused node (ensures inline
+    // elements are rendered in focused view).
+    await clickInEditor(pg, line);
+    await pg.waitForTimeout(200);
+
+    const el = line.locator(selector).first();
+    await clickInEditor(pg, el);
+    await pg.waitForTimeout(200);
+}
+
+/**
+ * Returns whether a toolbar button has the `.active` class.
+ * @param {import('@playwright/test').Page} pg
+ * @param {string} buttonId - The `data-button-id` value
+ * @returns {Promise<boolean>}
+ */
+async function isButtonActive(pg, buttonId) {
+    return pg
+        .locator(`[data-button-id="${buttonId}"]`)
+        .evaluate((el) => el.classList.contains('active'));
+}
+
+/**
+ * Returns the active state for all inline format buttons.
+ * @param {import('@playwright/test').Page} pg
+ * @returns {Promise<Record<string, boolean>>}
+ */
+async function getFormatButtonStates(pg) {
+    const ids = ['bold', 'italic', 'strikethrough', 'subscript', 'superscript', 'code', 'link'];
+    /** @type {Record<string, boolean>} */
+    const result = {};
+    for (const id of ids) {
+        result[id] = await isButtonActive(pg, id);
+    }
+    return result;
+}
+
+// ─── Tests ─────────────────────────────────────────────────────────
+
+test('bold button is active when cursor is inside bold text', async () => {
+    await loadContent(page, fixtureContent);
+    await setFocusedView(page);
+
+    // Line 0: "This is **bold text** here."
+    // Click inside the <strong> element.
+    await clickInlineElement(page, 0, 'strong');
+
+    const states = await getFormatButtonStates(page);
+    expect(states.bold).toBe(true);
+    expect(states.italic).toBe(false);
+    expect(states.strikethrough).toBe(false);
+    expect(states.code).toBe(false);
+});
+
+test('italic button is active when cursor is inside italic text', async () => {
+    await loadContent(page, fixtureContent);
+    await setFocusedView(page);
+
+    // Line 1: "This is *italic text* here."
+    await clickInlineElement(page, 1, 'em');
+
+    const states = await getFormatButtonStates(page);
+    expect(states.bold).toBe(false);
+    expect(states.italic).toBe(true);
+    expect(states.strikethrough).toBe(false);
+    expect(states.code).toBe(false);
+});
+
+test('bold and italic buttons are active when cursor is inside bold-italic text', async () => {
+    await loadContent(page, fixtureContent);
+    await setFocusedView(page);
+
+    // Line 2: "This is ***bold italic*** here."
+    // bold-italic renders as <strong><em>...</em></strong>
+    await clickInlineElement(page, 2, 'strong');
+
+    const states = await getFormatButtonStates(page);
+    expect(states.bold).toBe(true);
+    expect(states.italic).toBe(true);
+    expect(states.strikethrough).toBe(false);
+    expect(states.code).toBe(false);
+});
+
+test('strikethrough button is active when cursor is inside strikethrough text', async () => {
+    await loadContent(page, fixtureContent);
+    await setFocusedView(page);
+
+    // Line 3: "This is ~~struck~~ here."
+    await clickInlineElement(page, 3, 'del');
+
+    const states = await getFormatButtonStates(page);
+    expect(states.bold).toBe(false);
+    expect(states.italic).toBe(false);
+    expect(states.strikethrough).toBe(true);
+    expect(states.code).toBe(false);
+});
+
+test('code button is active when cursor is inside inline code', async () => {
+    await loadContent(page, fixtureContent);
+    await setFocusedView(page);
+
+    // Line 4: "This is `code` here."
+    await clickInlineElement(page, 4, 'code');
+
+    const states = await getFormatButtonStates(page);
+    expect(states.bold).toBe(false);
+    expect(states.italic).toBe(false);
+    expect(states.strikethrough).toBe(false);
+    expect(states.code).toBe(true);
+});
+
+test('no format buttons are active when cursor is in plain text', async () => {
+    await loadContent(page, fixtureContent);
+    await setFocusedView(page);
+
+    // Line 5: "Plain paragraph."
+    const line = page.locator('#editor .md-line').nth(5);
+    await clickInEditor(page, line);
+    await page.waitForTimeout(200);
+
+    const states = await getFormatButtonStates(page);
+    expect(states.bold).toBe(false);
+    expect(states.italic).toBe(false);
+    expect(states.strikethrough).toBe(false);
+    expect(states.code).toBe(false);
+    expect(states.link).toBe(false);
+});
+
+test('paragraph button stays active when cursor is inside bold text in a paragraph', async () => {
+    await loadContent(page, fixtureContent);
+    await setFocusedView(page);
+
+    // Line 0: paragraph with bold text
+    await clickInlineElement(page, 0, 'strong');
+
+    const paragraphActive = await isButtonActive(page, 'paragraph');
+    expect(paragraphActive).toBe(true);
+});


### PR DESCRIPTION
Closes #48
Closes #75

### Problem

When the cursor was inside inline formatting (bold, italic, etc.), `treeCursor.nodeId` always pointed at the block-level parent (paragraph, heading, list-item). The toolbar had no way to know which inline formats were active at the cursor position, so format buttons never showed an active/pressed state.

Additionally, the subscript and superscript buttons could not toggle off — pressing them on already-formatted text would wrap it in a second layer of `<sub>`/`<sup>` tags. And sub/sup were not mutually exclusive: pressing superscript on subscript text would nest `<sup>` inside `<sub>`.

### Changes

**Architecture — true inline cursor (`treeCursor`)**
- `treeCursor.nodeId` now points to the **inline child** node (e.g. the `bold` SyntaxNode) when the cursor is inside formatting. A new `treeCursor.blockNodeId` field always holds the block parent's id.
- `Editor.getCurrentNode()` returns the inline node; `Editor.getCurrentBlockNode()` returns the block parent. All editing operations updated to use `getCurrentBlockNode()`.
- `SyntaxNode.getBlockParent()` and `isInlineNode()` helpers added.

**Focused renderer — `data-node-id` on inline elements**
- `renderSyntaxNodeChildren()` renders inline children from the syntax tree with `data-node-id` on every formatting element (`<strong>`, `<em>`, `<del>`, `<code>`, `<a>`, `<sub>`, `<sup>`).
- `_mapDOMPositionToTree` in cursor-manager detects inline `data-node-id` elements and records the inline node id while computing offset relative to the block parent.

**Toolbar active states**
- `updateButtonStates(node)` walks from the (potentially inline) node up through `.parent` to collect active formats, resolves to block parent for block-type checks.
- `Toolbar.INLINE_TYPE_TO_BUTTONS` maps inline node types to button IDs.
- Toolbar button order reordered: structural buttons first, separator, then inline formatting.

**Sub/sup toggle & mutual exclusion**
- `_findFormatSpan` now handles `subscript`/`superscript` by scanning `html-open`/`html-close` tokens with matching tag names, enabling proper toggle-off.
- `applyFormat` checks for the opposite format before wrapping — pressing superscript on subscript text strips sub and applies sup (and vice versa).

### Testing

- 7 new integration tests (`toolbar-active.spec.js`) covering bold, italic, bold-italic, strikethrough, code, plain text, and block-button-stays-active scenarios.
- All 262 unit tests pass, all 253 integration tests pass, lint/format/typing clean.
- Manually verified: toolbar buttons highlight correctly, sub/sup toggle and mutual exclusion work, editing operations (typing, backspace, enter) unaffected.