### PR TITLE
Refactor: separate parsing from data structures, unify html-element type

### DIFF
--- a/@tooling/parser/src/dfa-parser.js
+++ b/@tooling/parser/src/dfa-parser.js
@@ -9,6 +9,18 @@
 
 import { tokenize } from './dfa-tokenizer.js';
 import { SyntaxNode, SyntaxTree } from '../../syntax-tree/src/syntax-tree.js';
+import { parseInlineContent } from './parse-inline-content.js';
+
+/**
+ * Populates a node's inline children by parsing its content.
+ * @param {SyntaxNode} node
+ */
+function populateInlineChildren(node) {
+    if (!node.content) return;
+    for (const child of parseInlineContent(node.content)) {
+        node.appendChild(child);
+    }
+}
 
 // ── Block-level HTML tag set (GFM type 6) ───────────────────────────
 
@@ -256,6 +268,7 @@ export class DFAParser {
         const content = this.consumeToEndOfLine(ctx);
 
         const node = new SyntaxNode(`heading${level}`, content);
+        populateInlineChildren(node);
         node.startLine = startLine;
         node.endLine = startLine;
         return node;
@@ -382,6 +395,7 @@ export class DFAParser {
         }
 
         const node = new SyntaxNode('blockquote', contentLines.join('\n'));
+        populateInlineChildren(node);
         node.startLine = startLine;
         node.endLine = ctx.line > startLine ? ctx.line - 1 : startLine;
         return node;
@@ -455,6 +469,7 @@ export class DFAParser {
         }
 
         const node = new SyntaxNode('list-item', itemContent);
+        populateInlineChildren(node);
         node.attributes = { ordered: false, indent };
         node.runtime.marker = marker;
         if (typeof checkedAttr === 'boolean') {
@@ -530,6 +545,7 @@ export class DFAParser {
         const content = this.consumeToEndOfLine(ctx);
 
         const node = new SyntaxNode('list-item', content);
+        populateInlineChildren(node);
         node.attributes = { ordered: true, number, indent };
         node.startLine = startLine;
         node.endLine = startLine;
@@ -1036,7 +1052,7 @@ export class DFAParser {
                 ctx.line++;
                 ctx.pos++;
             }
-            const node = new SyntaxNode('html-block', '');
+            const node = new SyntaxNode('html-element', '');
             node.tagName = lowerTagName;
             node.attributes = {};
             node.runtime.openingTag = openingTag;
@@ -1103,7 +1119,7 @@ export class DFAParser {
         }
 
         // Create the container node
-        const node = new SyntaxNode('html-block', '');
+        const node = new SyntaxNode('html-element', '');
         node.tagName = lowerTagName;
         node.attributes = {};
         node.runtime.openingTag = openingTag;
@@ -1176,7 +1192,7 @@ export class DFAParser {
         }
 
         // Build the node structure matching the existing parser's output
-        const node = new SyntaxNode('html-block', '');
+        const node = new SyntaxNode('html-element', '');
         node.tagName = tagName;
         node.attributes = {};
         node.runtime.openingTag = openingTag;
@@ -1185,6 +1201,7 @@ export class DFAParser {
         node.endLine = startLine;
 
         const child = new SyntaxNode('paragraph', content.trim());
+        populateInlineChildren(child);
         child.attributes = { bareText: true };
         child.startLine = startLine;
         child.endLine = startLine;
@@ -1304,8 +1321,8 @@ export class DFAParser {
             const headerCells = this.parseTableRow(lines[0]);
             const header = new SyntaxNode('header', '');
             for (const cellText of headerCells) {
-                const cell = new SyntaxNode('cell', '');
-                cell.appendChild(new SyntaxNode('text', cellText));
+                const cell = new SyntaxNode('cell', cellText);
+                populateInlineChildren(cell);
                 header.appendChild(cell);
             }
             node.appendChild(header);
@@ -1317,8 +1334,8 @@ export class DFAParser {
             const rowCells = this.parseTableRow(lines[r]);
             const row = new SyntaxNode('row', '');
             for (const cellText of rowCells) {
-                const cell = new SyntaxNode('cell', '');
-                cell.appendChild(new SyntaxNode('text', cellText));
+                const cell = new SyntaxNode('cell', cellText);
+                populateInlineChildren(cell);
                 row.appendChild(cell);
             }
             node.appendChild(row);
@@ -1382,6 +1399,7 @@ export class DFAParser {
         }
 
         const node = new SyntaxNode('paragraph', content);
+        populateInlineChildren(node);
         node.startLine = startLine;
         node.endLine = ctx.line > startLine ? ctx.line - 1 : startLine;
         return node;

--- a/@tooling/parser/src/inline-tokenizer.js
+++ b/@tooling/parser/src/inline-tokenizer.js
@@ -5,17 +5,52 @@
  * inline syntax (`**`, `*`, `_`, `__`, `~~`, `` ` ``, `[]()`) and HTML
  * inline tags (`<strong>`, `<em>`, `<sub>`, `<sup>`, etc.).
  *
- * The token list is then assembled into a tree of inline segments by
- * {@link buildInlineTree}, which a renderer can walk to produce DOM nodes.
+ * The token list is consumed by {@link parseInlineContent} in
+ * syntax-tree.js, which assembles it into SyntaxNode children.
  */
 
-// ── Known inline HTML tags ──────────────────────────────────────────
-//
-// Adding support for a new inline HTML tag is a one-line change: just
-// add the tag name to this set.
+// ── Void HTML elements ──────────────────────────────────────────────
 
 /** @type {Set<string>} */
-const INLINE_HTML_TAGS = new Set(['strong', 'em', 'del', 's', 'sub', 'sup', 'mark', 'u', 'b', 'i']);
+const VOID_HTML_ELEMENTS = new Set([
+    'area', 'base', 'br', 'col', 'embed', 'hr', 'img', 'input',
+    'link', 'meta', 'param', 'source', 'track', 'wbr',
+]);
+
+// ── HTML helpers ────────────────────────────────────────────────────
+
+/**
+ * Finds the closing '>' for a tag, skipping '>' inside quoted attributes.
+ * @param {string} input
+ * @param {number} start - Position after the '<'
+ * @returns {number} Index of closing '>', or -1
+ */
+function findClosingAngle(input, start) {
+    let inDouble = false;
+    let inSingle = false;
+    for (let j = start; j < input.length; j++) {
+        const c = input[j];
+        if (c === '"' && !inSingle) inDouble = !inDouble;
+        else if (c === "'" && !inDouble) inSingle = !inSingle;
+        else if (c === '>' && !inDouble && !inSingle) return j;
+    }
+    return -1;
+}
+
+/**
+ * Parses HTML attribute key-value pairs from a string.
+ * @param {string} str - e.g. 'src="x.png" alt="pic"'
+ * @returns {Record<string, string>}
+ */
+function parseHTMLAttributes(str) {
+    const attrs = {};
+    const re = /([a-zA-Z_:][\w:.-]*)(?:\s*=\s*(?:"([^"]*)"|'([^']*)'|(\S+)))?/g;
+    let m;
+    while ((m = re.exec(str)) !== null) {
+        attrs[m[1]] = m[2] ?? m[3] ?? m[4] ?? '';
+    }
+    return attrs;
+}
 
 // ── Token types ─────────────────────────────────────────────────────
 
@@ -25,7 +60,7 @@ const INLINE_HTML_TAGS = new Set(['strong', 'em', 'del', 's', 'sub', 'sup', 'mar
  *   |'strikethrough-open'|'strikethrough-close'|'code'
  *   |'link-open'|'link-close'|'link-href'
  *   |'image'
- *   |'html-open'|'html-close'} TokenType
+ *   |'html-open'|'html-close'|'html-void'} TokenType
  */
 
 /**
@@ -33,7 +68,8 @@ const INLINE_HTML_TAGS = new Set(['strong', 'em', 'del', 's', 'sub', 'sup', 'mar
  * @property {TokenType} type
  * @property {string} raw      - The original source text of the token.
  * @property {string} [content] - Inner content (for code spans / text).
- * @property {string} [tag]     - HTML tag name (for html-open / html-close).
+ * @property {string} [tag]     - HTML tag name (for html-open / html-close / html-void).
+ * @property {Record<string, string>} [attrs] - HTML attributes (for html-open / html-void).
  * @property {string} [href]    - Link URL (for link-href).
  * @property {string} [alt]     - Alt text (for image tokens).
  * @property {string} [src]     - Image URL (for image tokens).
@@ -280,42 +316,44 @@ export function tokenizeInline(input) {
             }
         }
 
-        // ── <tag> / </tag> HTML inline tags ──────────────────────
+        // ── <tag> / </tag> / <tag /> HTML tags ──────────────────
         if (ch === '<') {
-            const closeAngle = input.indexOf('>', i + 1);
+            const closeAngle = findClosingAngle(input, i + 1);
             if (closeAngle !== -1) {
                 const tagContent = input.slice(i + 1, closeAngle);
                 // Closing tag: </tagname>
                 const closeMatch = tagContent.match(/^\/([a-zA-Z][a-zA-Z0-9]*)$/);
                 if (closeMatch) {
                     const tagName = closeMatch[1].toLowerCase();
-                    if (INLINE_HTML_TAGS.has(tagName)) {
-                        flushText(i);
-                        tokens.push({
-                            type: 'html-close',
-                            raw: input.slice(i, closeAngle + 1),
-                            tag: tagName,
-                        });
-                        i = closeAngle + 1;
-                        textStart = i;
-                        continue;
-                    }
+                    flushText(i);
+                    tokens.push({
+                        type: 'html-close',
+                        raw: input.slice(i, closeAngle + 1),
+                        tag: tagName,
+                    });
+                    i = closeAngle + 1;
+                    textStart = i;
+                    continue;
                 }
-                // Opening tag: <tagname> (no attributes for inline tags)
-                const openMatch = tagContent.match(/^([a-zA-Z][a-zA-Z0-9]*)$/);
+                // Opening or void tag: <tagname ...> or <tagname ... />
+                const openMatch = tagContent.match(/^([a-zA-Z][a-zA-Z0-9]*)([\s/].*)?$/);
                 if (openMatch) {
                     const tagName = openMatch[1].toLowerCase();
-                    if (INLINE_HTML_TAGS.has(tagName)) {
-                        flushText(i);
-                        tokens.push({
-                            type: 'html-open',
-                            raw: input.slice(i, closeAngle + 1),
-                            tag: tagName,
-                        });
-                        i = closeAngle + 1;
-                        textStart = i;
-                        continue;
-                    }
+                    const rest = (openMatch[2] || '').trim();
+                    const selfClosing = rest.endsWith('/');
+                    const attrString = selfClosing ? rest.slice(0, -1).trim() : rest;
+                    const attrs = attrString ? parseHTMLAttributes(attrString) : {};
+                    const isVoid = selfClosing || VOID_HTML_ELEMENTS.has(tagName);
+                    flushText(i);
+                    tokens.push({
+                        type: isVoid ? 'html-void' : 'html-open',
+                        raw: input.slice(i, closeAngle + 1),
+                        tag: tagName,
+                        attrs,
+                    });
+                    i = closeAngle + 1;
+                    textStart = i;
+                    continue;
                 }
             }
         }
@@ -327,216 +365,4 @@ export function tokenizeInline(input) {
     flushText(input.length);
 
     return tokens;
-}
-
-// ── Tree builder ────────────────────────────────────────────────────
-
-/**
- * An inline segment: either plain text, a code span, or a formatted
- * container with children.
- *
- * @typedef {object} InlineSegment
- * @property {'text'|'code'|'image'|'bold'|'italic'|'strikethrough'|'link'|string} type
- * @property {string} [text]     - Plain text content (type === 'text').
- * @property {string} [content]  - Code content (type === 'code').
- * @property {string} [href]     - Link URL (type === 'link'). * @property {string} [alt]     - Alt text (type === 'image').
- * @property {string} [src]     - Image URL (type === 'image'). * @property {string} [tag]      - HTML tag name (for html inline elements).
- * @property {InlineSegment[]} [children] - Child segments for containers.
- */
-
-/**
- * Map from open token type to the corresponding close token type.
- * @type {Record<string, string>}
- */
-const CLOSE_TYPE_FOR = {
-    'bold-open': 'bold-close',
-    'italic-open': 'italic-close',
-    'bold-italic-open': 'bold-italic-close',
-    'strikethrough-open': 'strikethrough-close',
-    'link-open': 'link-close',
-};
-
-/**
- * Map from open token type to segment type.
- * @type {Record<string, string>}
- */
-const SEGMENT_TYPE_FOR = {
-    'bold-open': 'bold',
-    'italic-open': 'italic',
-    'bold-italic-open': 'bold-italic',
-    'strikethrough-open': 'strikethrough',
-    'link-open': 'link',
-};
-
-/**
- * Builds a tree of inline segments from a flat token list.
- *
- * Uses a stack: when an open token is encountered, a new container is
- * pushed.  When the matching close is found, the container is popped
- * and appended to its parent.  Unmatched open/close tokens are emitted
- * as plain text.
- *
- * @param {InlineToken[]} tokens
- * @returns {InlineSegment[]}
- */
-export function buildInlineTree(tokens) {
-    /** @type {InlineSegment[][]} */
-    const stack = [[]]; // stack[0] is the root children list
-
-    /**
-     * Metadata for each open container on the stack.
-     * @type {Array<{type: string, closeType: string, raw: string, href?: string, tag?: string}>}
-     */
-    const openStack = [];
-
-    for (const token of tokens) {
-        const current = stack[stack.length - 1];
-
-        if (token.type === 'text') {
-            current.push({ type: 'text', text: token.raw });
-            continue;
-        }
-
-        if (token.type === 'code') {
-            current.push({ type: 'code', content: token.content });
-            continue;
-        }
-
-        if (token.type === 'image') {
-            current.push({ type: 'image', alt: token.alt, src: token.src });
-            continue;
-        }
-
-        // ── Markdown open tokens ────────────────────────────────
-        if (CLOSE_TYPE_FOR[token.type]) {
-            const closeType = CLOSE_TYPE_FOR[token.type];
-            const segType = SEGMENT_TYPE_FOR[token.type];
-            openStack.push({
-                type: segType,
-                closeType,
-                raw: token.raw,
-                href: token.href,
-            });
-            stack.push([]);
-            continue;
-        }
-
-        // ── Markdown close tokens ───────────────────────────────
-        if (
-            token.type === 'bold-close' ||
-            token.type === 'italic-close' ||
-            token.type === 'bold-italic-close' ||
-            token.type === 'strikethrough-close'
-        ) {
-            // Find the matching open on the stack
-            const idx = findMatchingOpen(openStack, token.type);
-            if (idx !== -1) {
-                // Pop everything from idx to top, collapsing unmatched opens
-                collapseStack(stack, openStack, idx);
-                const meta = /** @type {{type: string}} */ (openStack.pop());
-                const children = /** @type {InlineSegment[]} */ (stack.pop());
-                const parent = stack[stack.length - 1];
-                parent.push({ type: meta.type, children });
-            } else {
-                // Unmatched close — emit as text
-                current.push({ type: 'text', text: token.raw });
-            }
-            continue;
-        }
-
-        if (token.type === 'link-close') {
-            const idx = findMatchingOpen(openStack, 'link-close');
-            if (idx !== -1) {
-                collapseStack(stack, openStack, idx);
-                openStack.pop();
-                const children = /** @type {InlineSegment[]} */ (stack.pop());
-                const parent = stack[stack.length - 1];
-                parent.push({ type: 'link', href: token.href, children });
-            } else {
-                current.push({ type: 'text', text: token.raw });
-            }
-            continue;
-        }
-
-        // ── HTML open tags ──────────────────────────────────────
-        if (token.type === 'html-open') {
-            const tag = /** @type {string} */ (token.tag);
-            openStack.push({
-                type: tag,
-                closeType: `html-close:${tag}`,
-                raw: token.raw,
-                tag,
-            });
-            stack.push([]);
-            continue;
-        }
-
-        // ── HTML close tags ─────────────────────────────────────
-        if (token.type === 'html-close') {
-            const tag = /** @type {string} */ (token.tag);
-            const closeKey = `html-close:${tag}`;
-            const idx = findMatchingOpen(openStack, closeKey);
-            if (idx !== -1) {
-                collapseStack(stack, openStack, idx);
-                const meta = /** @type {{tag: string}} */ (openStack.pop());
-                const children = /** @type {InlineSegment[]} */ (stack.pop());
-                const parent = stack[stack.length - 1];
-                parent.push({ type: meta.tag, tag: meta.tag, children });
-            } else {
-                // Unmatched close tag — emit as text
-                current.push({ type: 'text', text: token.raw });
-            }
-        }
-    }
-
-    // Collapse any remaining unclosed opens as text
-    while (openStack.length > 0) {
-        const meta = /** @type {{raw: string}} */ (openStack.pop());
-        const children = /** @type {InlineSegment[]} */ (stack.pop());
-        const parent = stack[stack.length - 1];
-        // Emit the open delimiter as text, then append children
-        parent.push({ type: 'text', text: meta.raw });
-        for (const child of children) {
-            parent.push(child);
-        }
-    }
-
-    return stack[0];
-}
-
-/**
- * Finds the index of the most recent matching open entry on the stack.
- *
- * @param {Array<{closeType: string}>} openStack
- * @param {string} closeType
- * @returns {number} Index into openStack, or -1
- */
-function findMatchingOpen(openStack, closeType) {
-    for (let i = openStack.length - 1; i >= 0; i--) {
-        if (openStack[i].closeType === closeType) {
-            return i;
-        }
-    }
-    return -1;
-}
-
-/**
- * Collapses unmatched opens between `targetIdx + 1` and the top of the
- * stack, converting them back to plain text so they don't produce
- * phantom containers.
- *
- * @param {InlineSegment[][]} stack
- * @param {Array<{type: string, closeType: string, raw: string}>} openStack
- * @param {number} targetIdx
- */
-function collapseStack(stack, openStack, targetIdx) {
-    while (openStack.length - 1 > targetIdx) {
-        const meta = /** @type {{raw: string}} */ (openStack.pop());
-        const children = /** @type {InlineSegment[]} */ (stack.pop());
-        const parent = stack[stack.length - 1];
-        parent.push({ type: 'text', text: meta.raw });
-        for (const child of children) {
-            parent.push(child);
-        }
-    }
 }

--- a/@tooling/parser/src/parse-inline-content.js
+++ b/@tooling/parser/src/parse-inline-content.js
@@ -1,0 +1,220 @@
+/**
+ * @fileoverview Parses raw inline markdown into SyntaxNode children.
+ *
+ * Tokenizes the input via the inline tokenizer, then uses a stack to
+ * pair open/close tokens into nested container nodes.  Unmatched
+ * delimiters are emitted as plain text nodes.
+ */
+
+import { tokenizeInline } from './inline-tokenizer.js';
+import { SyntaxNode } from '../../syntax-tree/src/syntax-tree.js';
+
+// ── Token-type maps ─────────────────────────────────────────────────
+
+/**
+ * Map from open token type to the corresponding close token type.
+ * @type {Record<string, string>}
+ */
+const CLOSE_TYPE_FOR = {
+    'bold-open': 'bold-close',
+    'italic-open': 'italic-close',
+    'bold-italic-open': 'bold-italic-close',
+    'strikethrough-open': 'strikethrough-close',
+    'link-open': 'link-close',
+};
+
+/**
+ * Map from open token type to SyntaxNode type.
+ * @type {Record<string, string>}
+ */
+const NODE_TYPE_FOR = {
+    'bold-open': 'bold',
+    'italic-open': 'italic',
+    'bold-italic-open': 'bold-italic',
+    'strikethrough-open': 'strikethrough',
+    'link-open': 'link',
+};
+
+// ── Parser ──────────────────────────────────────────────────────────
+
+/**
+ * Parses inline markdown content into an array of SyntaxNodes.
+ *
+ * Tokenizes the input, then uses a stack to pair open/close tokens
+ * into nested container nodes. Unmatched delimiters are emitted as
+ * plain text.
+ *
+ * @param {string} content - Raw inline markdown text.
+ * @returns {SyntaxNode[]}
+ */
+export function parseInlineContent(content) {
+    if (!content) return [];
+    const tokens = tokenizeInline(content);
+
+    /** @type {SyntaxNode[][]} */
+    const stack = [[]]; // stack[0] is the root children list
+
+    /**
+     * Metadata for each open container on the stack.
+     * @type {Array<{type: string, closeType: string, raw: string, href?: string, tag?: string}>}
+     */
+    const openStack = [];
+
+    for (const token of tokens) {
+        const current = stack[stack.length - 1];
+
+        if (token.type === 'text') {
+            current.push(new SyntaxNode('text', token.raw));
+            continue;
+        }
+
+        if (token.type === 'code') {
+            current.push(new SyntaxNode('inline-code', token.content));
+            continue;
+        }
+
+        if (token.type === 'image') {
+            const img = new SyntaxNode('inline-image', '');
+            img.attributes.alt = token.alt ?? '';
+            img.attributes.src = token.src ?? '';
+            current.push(img);
+            continue;
+        }
+
+        // ── Markdown open tokens ────────────────────────────────
+        if (CLOSE_TYPE_FOR[token.type]) {
+            openStack.push({
+                type: NODE_TYPE_FOR[token.type],
+                closeType: CLOSE_TYPE_FOR[token.type],
+                raw: token.raw,
+                href: token.href,
+            });
+            stack.push([]);
+            continue;
+        }
+
+        // ── Markdown close tokens ───────────────────────────────
+        if (
+            token.type === 'bold-close' ||
+            token.type === 'italic-close' ||
+            token.type === 'bold-italic-close' ||
+            token.type === 'strikethrough-close'
+        ) {
+            const idx = findMatchingOpen(openStack, token.type);
+            if (idx !== -1) {
+                collapseStack(stack, openStack, idx);
+                const meta = openStack.pop();
+                const children = stack.pop();
+                const node = new SyntaxNode(meta.type, '');
+                for (const child of children) node.appendChild(child);
+                stack[stack.length - 1].push(node);
+            } else {
+                current.push(new SyntaxNode('text', token.raw));
+            }
+            continue;
+        }
+
+        if (token.type === 'link-close') {
+            const idx = findMatchingOpen(openStack, 'link-close');
+            if (idx !== -1) {
+                collapseStack(stack, openStack, idx);
+                openStack.pop();
+                const children = stack.pop();
+                const node = new SyntaxNode('link', '');
+                node.attributes.href = token.href ?? '';
+                for (const child of children) node.appendChild(child);
+                stack[stack.length - 1].push(node);
+            } else {
+                current.push(new SyntaxNode('text', token.raw));
+            }
+            continue;
+        }
+
+        // ── HTML void/self-closing tags ─────────────────────────
+        if (token.type === 'html-void') {
+            const node = new SyntaxNode('html-element', '');
+            node.tagName = /** @type {string} */ (token.tag);
+            Object.assign(node.attributes, token.attrs || {});
+            current.push(node);
+            continue;
+        }
+
+        // ── HTML open tags ──────────────────────────────────────
+        if (token.type === 'html-open') {
+            const tag = /** @type {string} */ (token.tag);
+            openStack.push({
+                type: tag,
+                closeType: `html-close:${tag}`,
+                raw: token.raw,
+                tag,
+                attrs: token.attrs || {},
+            });
+            stack.push([]);
+            continue;
+        }
+
+        // ── HTML close tags ─────────────────────────────────────
+        if (token.type === 'html-close') {
+            const tag = /** @type {string} */ (token.tag);
+            const closeKey = `html-close:${tag}`;
+            const idx = findMatchingOpen(openStack, closeKey);
+            if (idx !== -1) {
+                collapseStack(stack, openStack, idx);
+                const meta = openStack.pop();
+                const children = stack.pop();
+                const node = new SyntaxNode('html-element', '');
+                node.tagName = meta.tag;
+                Object.assign(node.attributes, meta.attrs || {});
+                for (const child of children) node.appendChild(child);
+                stack[stack.length - 1].push(node);
+            } else {
+                current.push(new SyntaxNode('text', token.raw));
+            }
+        }
+    }
+
+    // Collapse any remaining unclosed opens as text
+    while (openStack.length > 0) {
+        const meta = openStack.pop();
+        const children = stack.pop();
+        const parent = stack[stack.length - 1];
+        parent.push(new SyntaxNode('text', meta.raw));
+        for (const child of children) {
+            parent.push(child);
+        }
+    }
+
+    return stack[0];
+}
+
+/**
+ * Finds the index of the most recent matching open entry on the stack.
+ * @param {Array<{closeType: string}>} openStack
+ * @param {string} closeType
+ * @returns {number}
+ */
+function findMatchingOpen(openStack, closeType) {
+    for (let i = openStack.length - 1; i >= 0; i--) {
+        if (openStack[i].closeType === closeType) return i;
+    }
+    return -1;
+}
+
+/**
+ * Collapses unmatched opens between `targetIdx + 1` and the top of
+ * the stack, converting them back to plain text nodes.
+ * @param {SyntaxNode[][]} stack
+ * @param {Array<{raw: string}>} openStack
+ * @param {number} targetIdx
+ */
+function collapseStack(stack, openStack, targetIdx) {
+    while (openStack.length - 1 > targetIdx) {
+        const meta = openStack.pop();
+        const children = stack.pop();
+        const parent = stack[stack.length - 1];
+        parent.push(new SyntaxNode('text', meta.raw));
+        for (const child of children) {
+            parent.push(child);
+        }
+    }
+}

--- a/@tooling/parser/tests/spec-files/html-blocks.md
+++ b/@tooling/parser/tests/spec-files/html-blocks.md
@@ -11,7 +11,7 @@ Tests for HTML blocks including details/summary, div, and custom elements.
 # syntax tree
 
 ```
-html-block "summary"
+html-element "summary"
   paragraph {"bareText":true}
     text "Some text"
 ```
@@ -40,8 +40,8 @@ better
 # syntax tree
 
 ```
-html-block "details"
-  html-block "summary"
+html-element "details"
+  html-element "summary"
     paragraph {"bareText":true}
       text "This is a paragraph"
   heading2
@@ -77,7 +77,7 @@ Paragraph
 # syntax tree
 
 ```
-html-block "div"
+html-element "div"
   heading1
     text "Title"
   paragraph
@@ -108,7 +108,7 @@ Hello
 # syntax tree
 
 ```
-html-block "my-component"
+html-element "my-component"
   paragraph
     text "Hello"
 ```
@@ -132,7 +132,7 @@ html-block "my-component"
 # syntax tree
 
 ```
-html-block "app-header"
+html-element "app-header"
   paragraph {"bareText":true}
     text "Title text"
 ```
@@ -158,7 +158,7 @@ Body
 # syntax tree
 
 ```
-html-block "my-element"
+html-element "my-element"
   paragraph
     text "Body"
 ```
@@ -192,15 +192,15 @@ Test text
 ```
 paragraph
   text "Test text"
-html-block "section"
-  html-block "div"
-    html-block "p"
+html-element "section"
+  html-element "div"
+    html-element "p"
       paragraph {"bareText":true}
         text "some "
-        html-inline "i"
+        html-element "i"
           text "italic"
         text " and "
-        html-inline "b"
+        html-element "b"
           text "bold"
         text " text"
 paragraph
@@ -244,8 +244,8 @@ Test text
 ```
 paragraph
   text "Test text"
-html-block "section"
-  html-block "div"
+html-element "section"
+  html-element "div"
     paragraph
       text "    # this is not a heading text"
     heading1

--- a/@tooling/parser/tests/spec-files/images.md
+++ b/@tooling/parser/tests/spec-files/images.md
@@ -137,7 +137,7 @@ paragraph
 # syntax tree
 
 ```
-html-block "img" {"src":"photo.png","alt":"A photo","style":"zoom: 80%;"}
+html-element "img" {"src":"photo.png","alt":"A photo","style":"zoom: 80%;"}
 ```
 
 # html
@@ -157,7 +157,7 @@ html-block "img" {"src":"photo.png","alt":"A photo","style":"zoom: 80%;"}
 # syntax tree
 
 ```
-html-block "img" {"src":"pic.jpg","alt":"test"}
+html-element "img" {"src":"pic.jpg","alt":"test"}
 ```
 
 # html

--- a/@tooling/parser/tests/spec-files/inline-formatting.md
+++ b/@tooling/parser/tests/spec-files/inline-formatting.md
@@ -156,7 +156,7 @@ H<sub>2</sub>O
 ```
 paragraph
   text "H"
-  html-inline "sub"
+  html-element "sub"
     text "2"
   text "O"
 ```
@@ -180,10 +180,10 @@ x<sup>2</sup> + y<sup>3</sup>
 ```
 paragraph
   text "x"
-  html-inline "sup"
+  html-element "sup"
     text "2"
   text " + y"
-  html-inline "sup"
+  html-element "sup"
     text "3"
 ```
 
@@ -206,7 +206,7 @@ This is <strong>strong text</strong> here.
 ```
 paragraph
   text "This is "
-  html-inline "strong"
+  html-element "strong"
     text "strong text"
   text " here."
 ```
@@ -230,7 +230,7 @@ This is <em>emphasis text</em> here.
 ```
 paragraph
   text "This is "
-  html-inline "em"
+  html-element "em"
     text "emphasis text"
   text " here."
 ```

--- a/@tooling/parser/tests/spec-files/tables.md
+++ b/@tooling/parser/tests/spec-files/tables.md
@@ -163,3 +163,57 @@ paragraph
 </table>
 <p>Some text</p>
 ```
+
+---
+
+# markdown
+
+```
+| Style | Format | Media |
+|---|---|---|
+| *italic* | **bold** | <div><img src="x.png" alt="pic"></div> |
+```
+
+# syntax tree
+
+```
+table
+  header
+    cell
+      text "Style"
+    cell
+      text "Format"
+    cell
+      text "Media"
+  row
+    cell
+      italic
+        text "italic"
+    cell
+      bold
+        text "bold"
+    cell
+      html-element "div"
+        html-element "img" {"src":"x.png","alt":"pic"}
+```
+
+# html
+
+```
+<table>
+  <thead>
+    <tr>
+      <th>Style</th>
+      <th>Format</th>
+      <th>Media</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><em>italic</em></td>
+      <td><strong>bold</strong></td>
+      <td><div><img src="x.png" alt="pic"></div></td>
+    </tr>
+  </tbody>
+</table>
+```

--- a/@tooling/syntax-tree/index.js
+++ b/@tooling/syntax-tree/index.js
@@ -6,5 +6,8 @@
  */
 
 export { SyntaxNode, SyntaxTree } from './src/syntax-tree.js';
+export { parseInlineContent } from '../parser/src/parse-inline-content.js';
 export { serializeTree } from './src/serialize-tree.js';
-export { tokenizeInline, buildInlineTree } from './src/inline-tokenizer.js';
+export { serializeTreeMarkdown, serializeNodeMarkdown } from './src/render-tree-as-markdown.js';
+export { renderTreeToDOM, renderNodeToDOM } from './src/render-tree-as-dom.js';
+export { tokenizeInline } from '../parser/src/inline-tokenizer.js';

--- a/@tooling/syntax-tree/src/render-tree-as-dom.js
+++ b/@tooling/syntax-tree/src/render-tree-as-dom.js
@@ -1,0 +1,324 @@
+/**
+ * @fileoverview Renders a SyntaxTree / SyntaxNode into DOM elements.
+ *
+ * Every created element gets an `__st_node` back-reference to the
+ * originating SyntaxNode so that the editor can map DOM ↔ tree.
+ */
+
+// ── Inline helpers ──────────────────────────────────────────────────
+
+/**
+ * Appends inline SyntaxNode children as DOM nodes into a container.
+ * @param {Document} doc
+ * @param {SyntaxNode[]} children
+ * @param {Element|DocumentFragment} container
+ */
+function appendInlineChildrenToDOM(doc, children, container) {
+    for (const child of children) {
+        container.appendChild(inlineChildToDOM(doc, child));
+    }
+}
+
+/**
+ * Converts a single inline SyntaxNode child to a DOM node.
+ * @param {Document} doc
+ * @param {SyntaxNode} child
+ * @returns {Node}
+ */
+function inlineChildToDOM(doc, child) {
+    switch (child.type) {
+        case 'text':
+            return doc.createTextNode(child.content);
+
+        case 'inline-code': {
+            const code = doc.createElement('code');
+            code.__st_node = child;
+            code.textContent = child.content;
+            return code;
+        }
+
+        case 'inline-image': {
+            const img = doc.createElement('img');
+            img.__st_node = child;
+            img.setAttribute('src', child.attributes.src ?? '');
+            img.setAttribute('alt', child.attributes.alt ?? '');
+            return img;
+        }
+
+        case 'bold': {
+            const el = doc.createElement('strong');
+            el.__st_node = child;
+            appendInlineChildrenToDOM(doc, child.children, el);
+            return el;
+        }
+
+        case 'italic': {
+            const el = doc.createElement('em');
+            el.__st_node = child;
+            appendInlineChildrenToDOM(doc, child.children, el);
+            return el;
+        }
+
+        case 'bold-italic': {
+            const strong = doc.createElement('strong');
+            strong.__st_node = child;
+            const em = doc.createElement('em');
+            appendInlineChildrenToDOM(doc, child.children, em);
+            strong.appendChild(em);
+            return strong;
+        }
+
+        case 'strikethrough': {
+            const el = doc.createElement('del');
+            el.__st_node = child;
+            appendInlineChildrenToDOM(doc, child.children, el);
+            return el;
+        }
+
+        case 'link': {
+            const a = doc.createElement('a');
+            a.__st_node = child;
+            a.setAttribute('href', child.attributes.href ?? '');
+            appendInlineChildrenToDOM(doc, child.children, a);
+            return a;
+        }
+
+        case 'html-element': {
+            const el = doc.createElement(child.tagName);
+            el.__st_node = child;
+            for (const [attr, value] of Object.entries(child.attributes)) {
+                el.setAttribute(attr, value);
+            }
+            appendInlineChildrenToDOM(doc, child.children, el);
+            return el;
+        }
+
+        default: {
+            const el = doc.createElement(child.type);
+            el.__st_node = child;
+            appendInlineChildrenToDOM(doc, child.children, el);
+            return el;
+        }
+    }
+}
+
+// ── Block-level rendering ───────────────────────────────────────────
+
+/**
+ * Renders an array of block-level SyntaxNode children into a DOM
+ * container.
+ * @param {Document} doc
+ * @param {SyntaxNode[]} children
+ * @param {Element} container
+ */
+function renderBlockChildrenToDOM(doc, children, container) {
+    for (const child of children) {
+        container.appendChild(renderNodeToDOM(doc, child));
+    }
+}
+
+/**
+ * Converts a SyntaxNode to a DOM element.
+ * Each element gets an `__st_node` property referencing the node.
+ *
+ * @param {Document} doc - The Document to create elements with.
+ * @param {object} node - A SyntaxNode instance.
+ * @returns {Element}
+ */
+export function renderNodeToDOM(doc, node) {
+    switch (node.type) {
+        case 'heading1':
+        case 'heading2':
+        case 'heading3':
+        case 'heading4':
+        case 'heading5':
+        case 'heading6': {
+            const level = node.type.charAt(node.type.length - 1);
+            const el = doc.createElement(`h${level}`);
+            el.__st_node = node;
+            appendInlineChildrenToDOM(doc, node.children, el);
+            return el;
+        }
+
+        case 'paragraph': {
+            const el = doc.createElement('p');
+            el.__st_node = node;
+            appendInlineChildrenToDOM(doc, node.children, el);
+            return el;
+        }
+
+        case 'blockquote': {
+            const el = doc.createElement('blockquote');
+            el.__st_node = node;
+            appendInlineChildrenToDOM(doc, node.children, el);
+            return el;
+        }
+
+        case 'code-block': {
+            const pre = doc.createElement('pre');
+            pre.__st_node = node;
+            const code = doc.createElement('code');
+            if (node.attributes.language) {
+                code.setAttribute('class', `language-${node.attributes.language}`);
+            }
+            code.textContent = node.children.length > 0 ? node.children[0].content : node.content;
+            pre.appendChild(code);
+            return pre;
+        }
+
+        case 'list': {
+            const isOrdered = node.attributes.ordered;
+            const listEl = doc.createElement(isOrdered ? 'ol' : 'ul');
+            listEl.__st_node = node;
+            if (isOrdered && node.attributes.number > 1) {
+                listEl.setAttribute('start', String(node.attributes.number));
+            }
+            for (const child of node.children) {
+                listEl.appendChild(renderNodeToDOM(doc, child));
+            }
+            return listEl;
+        }
+
+        case 'list-item': {
+            const li = doc.createElement('li');
+            li.__st_node = node;
+            if (typeof node.attributes.checked === 'boolean') {
+                const checkbox = doc.createElement('input');
+                checkbox.setAttribute('type', 'checkbox');
+                if (node.attributes.checked) {
+                    checkbox.setAttribute('checked', '');
+                }
+                li.appendChild(checkbox);
+                li.appendChild(doc.createTextNode(' '));
+            }
+            // Append inline children (text, bold, etc.) but not nested lists
+            const inlineChildren = node.children.filter((c) => c.type !== 'list');
+            appendInlineChildrenToDOM(doc, inlineChildren, li);
+            // Append nested list children
+            for (const child of node.children) {
+                if (child.type === 'list') {
+                    li.appendChild(renderNodeToDOM(doc, child));
+                }
+            }
+            return li;
+        }
+
+        case 'horizontal-rule': {
+            const hr = doc.createElement('hr');
+            hr.__st_node = node;
+            return hr;
+        }
+
+        case 'image': {
+            const alt = node.attributes.alt ?? node.content ?? '';
+            const src = node.attributes.url ?? '';
+            const style = node.attributes.style ?? '';
+
+            const figure = doc.createElement('figure');
+            figure.__st_node = node;
+
+            if (alt) {
+                const figcaption = doc.createElement('figcaption');
+                figcaption.textContent = alt;
+                figure.appendChild(figcaption);
+            }
+
+            const img = doc.createElement('img');
+            img.setAttribute('src', src);
+            img.setAttribute('alt', alt);
+            if (style) img.setAttribute('style', style);
+
+            if (node.attributes.href) {
+                const a = doc.createElement('a');
+                a.setAttribute('href', node.attributes.href);
+                a.appendChild(img);
+                figure.appendChild(a);
+            } else {
+                figure.appendChild(img);
+            }
+
+            return figure;
+        }
+
+        case 'table': {
+            const table = doc.createElement('table');
+            table.__st_node = node;
+
+            const thead = doc.createElement('thead');
+            const tbody = doc.createElement('tbody');
+
+            for (const child of node.children) {
+                const tr = doc.createElement('tr');
+                const isHeader = child.type === 'header';
+                for (const cell of child.children) {
+                    const el = doc.createElement(isHeader ? 'th' : 'td');
+                    appendInlineChildrenToDOM(doc, cell.children, el);
+                    tr.appendChild(el);
+                }
+                if (isHeader) {
+                    thead.appendChild(tr);
+                } else {
+                    tbody.appendChild(tr);
+                }
+            }
+
+            if (thead.childNodes.length > 0) {
+                table.appendChild(thead);
+            }
+            if (tbody.childNodes.length > 0) {
+                table.appendChild(tbody);
+            }
+
+            return table;
+        }
+
+        case 'html-element': {
+            const tagName = node.tagName || 'div';
+            const el = doc.createElement(tagName);
+            el.__st_node = node;
+
+            if (node.runtime.openingTag) {
+                const temp = doc.createElement('div');
+                temp.innerHTML = node.runtime.openingTag;
+                const sourceEl = temp.firstElementChild;
+                if (sourceEl) {
+                    for (const attr of sourceEl.attributes) {
+                        el.setAttribute(attr.name, attr.value);
+                    }
+                }
+            }
+
+            if (
+                node.children.length === 1 &&
+                node.children[0].attributes.bareText &&
+                node.children[0].type === 'paragraph'
+            ) {
+                appendInlineChildrenToDOM(doc, node.children[0].children, el);
+            } else {
+                renderBlockChildrenToDOM(doc, node.children, el);
+            }
+
+            return el;
+        }
+
+        default: {
+            const el = doc.createElement('div');
+            el.__st_node = node;
+            el.textContent = node.content;
+            return el;
+        }
+    }
+}
+
+/**
+ * Renders a SyntaxTree into a DOM element.
+ *
+ * @param {Document} doc - The Document to create elements with.
+ * @param {object} tree - A SyntaxTree instance.
+ * @returns {Element}
+ */
+export function renderTreeToDOM(doc, tree) {
+    const container = doc.createElement('div');
+    renderBlockChildrenToDOM(doc, tree.children, container);
+    return container;
+}

--- a/@tooling/syntax-tree/src/render-tree-as-markdown.js
+++ b/@tooling/syntax-tree/src/render-tree-as-markdown.js
@@ -1,0 +1,194 @@
+/**
+ * @fileoverview Serializes a SyntaxTree back into markdown text.
+ *
+ * This is the inverse of the parser: it walks the tree and produces
+ * the markdown source that would round-trip back to the same tree.
+ */
+
+/**
+ * Serializes inline SyntaxNode children back to markdown text.
+ *
+ * @param {object[]} children - Array of inline SyntaxNode instances.
+ * @returns {string}
+ */
+function serializeInlineChildren(children) {
+    return children.map(serializeInlineNode).join('');
+}
+
+/**
+ * Serializes a single inline SyntaxNode to markdown text.
+ *
+ * @param {object} node
+ * @returns {string}
+ */
+function serializeInlineNode(node) {
+    switch (node.type) {
+        case 'text':
+            return node.content;
+        case 'inline-code':
+            return `\`${node.content}\``;
+        case 'bold':
+            return `**${serializeInlineChildren(node.children)}**`;
+        case 'italic':
+            return `*${serializeInlineChildren(node.children)}*`;
+        case 'bold-italic':
+            return `***${serializeInlineChildren(node.children)}***`;
+        case 'strikethrough':
+            return `~~${serializeInlineChildren(node.children)}~~`;
+        case 'link':
+            return `[${serializeInlineChildren(node.children)}](${node.attributes.href || ''})`;
+        case 'inline-image':
+            return `![${node.attributes.alt || ''}](${node.attributes.src || ''})`;
+        case 'html-element': {
+            const tag = node.tagName;
+            const attrs = Object.entries(node.attributes)
+                .map(([k, v]) => ` ${k}="${v}"`)
+                .join('');
+            if (node.children.length === 0) {
+                return `<${tag}${attrs}>`;
+            }
+            return `<${tag}${attrs}>${serializeInlineChildren(node.children)}</${tag}>`;
+        }
+        default:
+            return node.content || '';
+    }
+}
+
+/**
+ * Serializes a SyntaxTree into markdown.
+ *
+ * @param {object} tree - A SyntaxTree instance.
+ * @returns {string}
+ */
+export function serializeTreeMarkdown(tree) {
+    const lines = [];
+    for (const child of tree.children) {
+        lines.push(serializeNodeMarkdown(child));
+    }
+    return lines.join('\n\n') + '\n';
+}
+
+/**
+ * Serializes a single SyntaxNode into markdown.
+ *
+ * @param {object} node - A SyntaxNode instance.
+ * @param {number} [depth=0] - HTML nesting depth for indentation.
+ * @returns {string}
+ */
+export function serializeNodeMarkdown(node, depth = 0) {
+    switch (node.type) {
+        case 'heading1':
+            return `# ${node.content}`;
+        case 'heading2':
+            return `## ${node.content}`;
+        case 'heading3':
+            return `### ${node.content}`;
+        case 'heading4':
+            return `#### ${node.content}`;
+        case 'heading5':
+            return `##### ${node.content}`;
+        case 'heading6':
+            return `###### ${node.content}`;
+        case 'paragraph':
+            return node.content;
+        case 'blockquote':
+            return node.content
+                .split('\n')
+                .map((line) => `> ${line}`)
+                .join('\n');
+        case 'code-block': {
+            const lang = node.attributes.language || '';
+            const fence = '`'.repeat(node.attributes.fenceCount || 3);
+            const code = node.children.length > 0 ? node.children[0].content : node.content;
+            return `${fence}${lang}\n${code}\n${fence}`;
+        }
+        case 'list': {
+            return node.children.map((child) => serializeNodeMarkdown(child, depth)).join('\n');
+        }
+        case 'list-item': {
+            const listParent = node.parent;
+            const indent = listParent ? '  '.repeat(listParent.attributes.indent || 0) : '';
+            const marker = listParent?.attributes.ordered
+                ? `${listParent.attributes.number || 1}. `
+                : `${listParent?.runtime.marker || '-'} `;
+            const checkbox =
+                typeof node.attributes.checked === 'boolean'
+                    ? node.attributes.checked
+                        ? '[x] '
+                        : '[ ] '
+                    : '';
+            const lines = [`${indent}${marker}${checkbox}${node.content}`];
+            for (const child of node.children) {
+                if (child.type === 'list') {
+                    lines.push(serializeNodeMarkdown(child, depth));
+                }
+            }
+            return lines.join('\n');
+        }
+        case 'horizontal-rule': {
+            const hrMarker = node.attributes.marker || '-';
+            const hrCount = node.attributes.count || 3;
+            return hrMarker.repeat(hrCount);
+        }
+        case 'image': {
+            const imgAlt = node.attributes.alt ?? node.content;
+            const imgSrc = node.attributes.url ?? '';
+            const imgStyle = node.attributes.style ?? '';
+            if (imgStyle) {
+                const altAttr = imgAlt ? ` alt="${imgAlt}"` : '';
+                return `<img src="${imgSrc}"${altAttr} style="${imgStyle}" />`;
+            }
+            if (node.attributes.href) {
+                return `[![${imgAlt}](${imgSrc})](${node.attributes.href})`;
+            }
+            return `![${imgAlt}](${imgSrc})`;
+        }
+        case 'table': {
+            const rows = [];
+            for (const child of node.children) {
+                const cells = child.children.map((cell) => {
+                    return ` ${serializeInlineChildren(cell.children)} `;
+                });
+                rows.push(`|${cells.join('|')}|`);
+                // Insert separator after header
+                if (child.type === 'header') {
+                    const sep = child.children.map(() => '---');
+                    rows.push(`|${sep.join('|')}|`);
+                }
+            }
+            return rows.join('\n');
+        }
+        case 'html-element': {
+            const indent = '  '.repeat(depth);
+            // If the container has exactly one bare-text child, collapse
+            // to a single line: <tag>content</tag>
+            if (
+                node.children.length === 1 &&
+                node.children[0].attributes.bareText &&
+                node.children[0].type === 'paragraph'
+            ) {
+                const tag = node.tagName || 'div';
+                return `${indent}<${tag}>${node.children[0].content}</${tag}>`;
+            }
+
+            const lines = [`${indent}${node.runtime.openingTag || ''}`];
+            for (const child of node.children) {
+                if (child.type === 'html-element') {
+                    lines.push(serializeNodeMarkdown(child, depth + 1));
+                } else {
+                    lines.push('');
+                    lines.push(serializeNodeMarkdown(child));
+                    lines.push('');
+                }
+            }
+            if (node.runtime.closingTag) {
+                lines.push(`${indent}${node.runtime.closingTag}`);
+            }
+            // Collapse multiple consecutive blank lines
+            const result = lines.join('\n').replace(/\n{3,}/g, '\n\n');
+            return result;
+        }
+        default:
+            return node.content;
+    }
+}

--- a/@tooling/syntax-tree/src/serialize-tree.js
+++ b/@tooling/syntax-tree/src/serialize-tree.js
@@ -29,13 +29,11 @@ export function serializeTree(tree) {
  */
 function serializeNode(node, indent, lines) {
     const attrs = serializeAttributes(node.attributes);
-    const hasInlineChildren =
-        node.children.length > 0 &&
-        node.children.some((c) => c.type !== 'html-block');
-    // Use tagName as the quoted value for html-block and html-inline nodes
+    const hasChildren = node.children.length > 0;
+    // Use tagName as the quoted value for html-element nodes
     const quotedValue = node.tagName
         ? ` "${node.tagName}"`
-        : node.content && !hasInlineChildren
+        : node.content && !hasChildren
             ? ` "${node.content.length > 60 ? `${node.content.slice(0, 60)}...` : node.content}"`
             : '';
     lines.push(`${indent}${node.type}${quotedValue}${attrs}`);

--- a/@tooling/syntax-tree/src/syntax-tree.js
+++ b/@tooling/syntax-tree/src/syntax-tree.js
@@ -3,24 +3,8 @@
  * Provides a tree structure for representing parsed markdown.
  */
 
-import { buildInlineTree, tokenizeInline } from './inline-tokenizer.js';
-
-/**
- * Node types whose content contains inline formatting and should be
- * modelled as inline child nodes (text, bold, italic, link, etc.).
- * @type {Set<string>}
- */
-const INLINE_CONTENT_TYPES = new Set([
-    'paragraph',
-    'heading1',
-    'heading2',
-    'heading3',
-    'heading4',
-    'heading5',
-    'heading6',
-    'blockquote',
-    'list-item',
-]);
+import { serializeNodeMarkdown, serializeTreeMarkdown } from './render-tree-as-markdown.js';
+import { renderNodeToDOM, renderTreeToDOM } from './render-tree-as-dom.js';
 
 /**
  * @typedef {Object} NodeAttributes
@@ -36,7 +20,7 @@ const INLINE_CONTENT_TYPES = new Set([
  * @property {string} [src] - Image source URL (for inline-image nodes)
  * @property {string} [tag] - HTML tag name (for inline HTML element nodes)
  * @property {string} [style] - Inline CSS style string for HTML images
- * @property {string} [tagName] - HTML tag name for html-block nodes
+ * @property {string} [tagName] - HTML tag name for html-element nodes
  * @property {boolean} [checked] - Whether a checklist item is checked
  * @property {boolean} [bareText] - Whether this node represents bare text inside an HTML container
  */
@@ -86,7 +70,7 @@ export class SyntaxNode {
          * Child nodes.  For inline-containing block types (paragraph,
          * heading, blockquote, list-item), children are inline nodes
          * (text, bold, italic, link, etc.).  For container blocks
-         * (html-block), children are other block-level nodes.
+         * (html-element), children are other block-level nodes.
          * @type {SyntaxNode[]}
          */
         this.children = [];
@@ -98,7 +82,7 @@ export class SyntaxNode {
         this.parent = null;
 
         /**
-         * HTML tag name for html-block and html-inline nodes.
+         * HTML tag name for html-element nodes.
          * @type {string}
          */
         this.tagName = '';
@@ -126,60 +110,6 @@ export class SyntaxNode {
          * @type {number}
          */
         this.endLine = 0;
-
-        // Build inline children for types that contain inline formatting.
-        if (content && INLINE_CONTENT_TYPES.has(type)) {
-            this.buildInlineChildren();
-        }
-    }
-
-    /**
-     * (Re)builds inline child nodes from this node's raw content.
-     * Only meaningful for inline-containing types (paragraph, heading,
-     * blockquote, list-item).
-     */
-    buildInlineChildren() {
-        this.children = [];
-        if (!this.content) return;
-        const tokens = tokenizeInline(this.content);
-        const segments = buildInlineTree(tokens);
-        for (const seg of segments) {
-            this.appendChild(SyntaxNode.segmentToNode(seg));
-        }
-    }
-
-    /**
-     * Converts an InlineSegment (from buildInlineTree) into a SyntaxNode.
-     * @param {import('../../parser/src/inline-tokenizer.js').InlineSegment} segment
-     * @returns {SyntaxNode}
-     */
-    static segmentToNode(segment) {
-        switch (segment.type) {
-            case 'text':
-                return new SyntaxNode('text', segment.text ?? '');
-            case 'code':
-                return new SyntaxNode('inline-code', segment.content ?? '');
-            case 'image': {
-                const img = new SyntaxNode('inline-image', '');
-                img.attributes.alt = segment.alt ?? '';
-                img.attributes.src = segment.src ?? '';
-                return img;
-            }
-            default: {
-                // Containers: bold, italic, bold-italic, strikethrough,
-                // link, and HTML inline tags (sub, sup, etc.)
-                const isHtmlInline = !!segment.tag;
-                const node = new SyntaxNode(isHtmlInline ? 'html-inline' : segment.type, '');
-                if (isHtmlInline) node.tagName = segment.tag;
-                if (segment.href) node.attributes.href = segment.href;
-                if (segment.children) {
-                    for (const child of segment.children) {
-                        node.appendChild(SyntaxNode.segmentToNode(child));
-                    }
-                }
-                return node;
-            }
-        }
     }
 
     /**
@@ -197,323 +127,7 @@ export class SyntaxNode {
      * @returns {string}
      */
     toMarkdown(depth = 0) {
-        switch (this.type) {
-            case 'heading1':
-                return `# ${this.content}`;
-            case 'heading2':
-                return `## ${this.content}`;
-            case 'heading3':
-                return `### ${this.content}`;
-            case 'heading4':
-                return `#### ${this.content}`;
-            case 'heading5':
-                return `##### ${this.content}`;
-            case 'heading6':
-                return `###### ${this.content}`;
-            case 'paragraph':
-                return this.content;
-            case 'blockquote':
-                return this.content
-                    .split('\n')
-                    .map((line) => `> ${line}`)
-                    .join('\n');
-            case 'code-block': {
-                const lang = this.attributes.language || '';
-                const fence = '`'.repeat(this.attributes.fenceCount || 3);
-                const code = this.children.length > 0 ? this.children[0].content : this.content;
-                return `${fence}${lang}\n${code}\n${fence}`;
-            }
-            case 'list': {
-                return this.children.map((child) => child.toMarkdown(depth)).join('\n');
-            }
-            case 'list-item': {
-                const listParent = this.parent;
-                const indent = listParent ? '  '.repeat(listParent.attributes.indent || 0) : '';
-                const marker = listParent?.attributes.ordered
-                    ? `${listParent.attributes.number || 1}. `
-                    : `${listParent?.runtime.marker || '-'} `;
-                const checkbox =
-                    typeof this.attributes.checked === 'boolean'
-                        ? this.attributes.checked
-                            ? '[x] '
-                            : '[ ] '
-                        : '';
-                const lines = [`${indent}${marker}${checkbox}${this.content}`];
-                for (const child of this.children) {
-                    if (child.type === 'list') {
-                        lines.push(child.toMarkdown(depth));
-                    }
-                }
-                return lines.join('\n');
-            }
-            case 'horizontal-rule': {
-                const hrMarker = this.attributes.marker || '-';
-                const hrCount = this.attributes.count || 3;
-                return hrMarker.repeat(hrCount);
-            }
-            case 'image': {
-                const imgAlt = this.attributes.alt ?? this.content;
-                const imgSrc = this.attributes.url ?? '';
-                const imgStyle = this.attributes.style ?? '';
-                if (imgStyle) {
-                    const altAttr = imgAlt ? ` alt="${imgAlt}"` : '';
-                    return `<img src="${imgSrc}"${altAttr} style="${imgStyle}" />`;
-                }
-                if (this.attributes.href) {
-                    return `[![${imgAlt}](${imgSrc})](${this.attributes.href})`;
-                }
-                return `![${imgAlt}](${imgSrc})`;
-            }
-            case 'table': {
-                const rows = [];
-                for (const child of this.children) {
-                    const cells = child.children.map((cell) => {
-                        const text = cell.children.length > 0 ? cell.children[0].content : '';
-                        return ` ${text} `;
-                    });
-                    rows.push(`|${cells.join('|')}|`);
-                    // Insert separator after header
-                    if (child.type === 'header') {
-                        const sep = child.children.map(() => '---');
-                        rows.push(`|${sep.join('|')}|`);
-                    }
-                }
-                return rows.join('\n');
-            }
-            case 'html-block': {
-                const indent = '  '.repeat(depth);
-                // If the container has exactly one bare-text child, collapse
-                // to a single line: <tag>content</tag>
-                if (
-                    this.children.length === 1 &&
-                    this.children[0].attributes.bareText &&
-                    this.children[0].type === 'paragraph'
-                ) {
-                    const tag = this.tagName || 'div';
-                    return `${indent}<${tag}>${this.children[0].content}</${tag}>`;
-                }
-
-                const lines = [`${indent}${this.runtime.openingTag || ''}`];
-                for (const child of this.children) {
-                    if (child.type === 'html-block') {
-                        lines.push(child.toMarkdown(depth + 1));
-                    } else {
-                        lines.push('');
-                        lines.push(child.toMarkdown());
-                        lines.push('');
-                    }
-                }
-                if (this.runtime.closingTag) {
-                    lines.push(`${indent}${this.runtime.closingTag}`);
-                }
-                // Collapse multiple consecutive blank lines
-                const result = lines.join('\n').replace(/\n{3,}/g, '\n\n');
-                return result;
-            }
-            default:
-                return this.content;
-        }
-    }
-
-    /**
-     * Renders inline SyntaxNode children into a DOM container.
-     * @param {Document} doc
-     * @param {SyntaxNode[]} children
-     * @param {Element|DocumentFragment} container
-     */
-    static appendInlineChildrenToDOM(doc, children, container) {
-        for (const child of children) {
-            container.appendChild(SyntaxNode.inlineChildToDOM(doc, child));
-        }
-    }
-
-    /**
-     * Converts a single inline SyntaxNode child to a DOM node.
-     * @param {Document} doc
-     * @param {SyntaxNode} child
-     * @returns {Node}
-     */
-    static inlineChildToDOM(doc, child) {
-        switch (child.type) {
-            case 'text':
-                return doc.createTextNode(child.content);
-
-            case 'inline-code': {
-                const code = doc.createElement('code');
-                code.__st_node = child;
-                code.textContent = child.content;
-                return code;
-            }
-
-            case 'inline-image': {
-                const img = doc.createElement('img');
-                img.__st_node = child;
-                img.setAttribute('src', child.attributes.src ?? '');
-                img.setAttribute('alt', child.attributes.alt ?? '');
-                return img;
-            }
-
-            case 'bold': {
-                const el = doc.createElement('strong');
-                el.__st_node = child;
-                SyntaxNode.appendInlineChildrenToDOM(doc, child.children, el);
-                return el;
-            }
-
-            case 'italic': {
-                const el = doc.createElement('em');
-                el.__st_node = child;
-                SyntaxNode.appendInlineChildrenToDOM(doc, child.children, el);
-                return el;
-            }
-
-            case 'bold-italic': {
-                const strong = doc.createElement('strong');
-                strong.__st_node = child;
-                const em = doc.createElement('em');
-                SyntaxNode.appendInlineChildrenToDOM(doc, child.children, em);
-                strong.appendChild(em);
-                return strong;
-            }
-
-            case 'strikethrough': {
-                const el = doc.createElement('del');
-                el.__st_node = child;
-                SyntaxNode.appendInlineChildrenToDOM(doc, child.children, el);
-                return el;
-            }
-
-            case 'link': {
-                const a = doc.createElement('a');
-                a.__st_node = child;
-                a.setAttribute('href', child.attributes.href ?? '');
-                SyntaxNode.appendInlineChildrenToDOM(doc, child.children, a);
-                return a;
-            }
-
-            case 'html-inline': {
-                const el = doc.createElement(child.tagName);
-                el.__st_node = child;
-                SyntaxNode.appendInlineChildrenToDOM(doc, child.children, el);
-                return el;
-            }
-
-            default: {
-                const el = doc.createElement(child.type);
-                el.__st_node = child;
-                SyntaxNode.appendInlineChildrenToDOM(doc, child.children, el);
-                return el;
-            }
-        }
-    }
-
-    /**
-     * Renders raw inline markdown content to a DocumentFragment.
-     * Used for table cells and other contexts where inline children
-     * aren't pre-built as SyntaxNodes.
-     * @param {Document} doc
-     * @param {string} content
-     * @returns {DocumentFragment}
-     */
-    static renderInlineContentToDOM(doc, content) {
-        const frag = doc.createDocumentFragment();
-        const tokens = tokenizeInline(content);
-        const segments = buildInlineTree(tokens);
-        for (const seg of segments) {
-            frag.appendChild(SyntaxNode.segmentToDOM(doc, seg));
-        }
-        return frag;
-    }
-
-    /**
-     * Converts an InlineSegment to a DOM node.
-     * @param {Document} doc
-     * @param {import('../../parser/src/inline-tokenizer.js').InlineSegment} segment
-     * @returns {Node}
-     */
-    static segmentToDOM(doc, segment) {
-        switch (segment.type) {
-            case 'text':
-                return doc.createTextNode(segment.text ?? '');
-
-            case 'code': {
-                const code = doc.createElement('code');
-                code.textContent = segment.content ?? '';
-                return code;
-            }
-
-            case 'image': {
-                const img = doc.createElement('img');
-                img.setAttribute('src', segment.src ?? '');
-                img.setAttribute('alt', segment.alt ?? '');
-                return img;
-            }
-
-            case 'bold': {
-                const el = doc.createElement('strong');
-                if (segment.children) {
-                    for (const child of segment.children) {
-                        el.appendChild(SyntaxNode.segmentToDOM(doc, child));
-                    }
-                }
-                return el;
-            }
-
-            case 'italic': {
-                const el = doc.createElement('em');
-                if (segment.children) {
-                    for (const child of segment.children) {
-                        el.appendChild(SyntaxNode.segmentToDOM(doc, child));
-                    }
-                }
-                return el;
-            }
-
-            case 'bold-italic': {
-                const strong = doc.createElement('strong');
-                const em = doc.createElement('em');
-                if (segment.children) {
-                    for (const child of segment.children) {
-                        em.appendChild(SyntaxNode.segmentToDOM(doc, child));
-                    }
-                }
-                strong.appendChild(em);
-                return strong;
-            }
-
-            case 'strikethrough': {
-                const el = doc.createElement('del');
-                if (segment.children) {
-                    for (const child of segment.children) {
-                        el.appendChild(SyntaxNode.segmentToDOM(doc, child));
-                    }
-                }
-                return el;
-            }
-
-            case 'link': {
-                const a = doc.createElement('a');
-                a.setAttribute('href', segment.href ?? '');
-                if (segment.children) {
-                    for (const child of segment.children) {
-                        a.appendChild(SyntaxNode.segmentToDOM(doc, child));
-                    }
-                }
-                return a;
-            }
-
-            default: {
-                // HTML inline tags (sub, sup, mark, u, etc.)
-                const tag = segment.tag || segment.type;
-                const el = doc.createElement(tag);
-                if (segment.children) {
-                    for (const child of segment.children) {
-                        el.appendChild(SyntaxNode.segmentToDOM(doc, child));
-                    }
-                }
-                return el;
-            }
-        }
+        return serializeNodeMarkdown(this, depth);
     }
 
     /**
@@ -524,204 +138,7 @@ export class SyntaxNode {
      * @returns {Element}
      */
     toDOM(doc) {
-        switch (this.type) {
-            case 'heading1':
-            case 'heading2':
-            case 'heading3':
-            case 'heading4':
-            case 'heading5':
-            case 'heading6': {
-                const level = this.type.charAt(this.type.length - 1);
-                const el = doc.createElement(`h${level}`);
-                el.__st_node = this;
-                SyntaxNode.appendInlineChildrenToDOM(doc, this.children, el);
-                return el;
-            }
-
-            case 'paragraph': {
-                const el = doc.createElement('p');
-                el.__st_node = this;
-                SyntaxNode.appendInlineChildrenToDOM(doc, this.children, el);
-                return el;
-            }
-
-            case 'blockquote': {
-                const el = doc.createElement('blockquote');
-                el.__st_node = this;
-                SyntaxNode.appendInlineChildrenToDOM(doc, this.children, el);
-                return el;
-            }
-
-            case 'code-block': {
-                const pre = doc.createElement('pre');
-                pre.__st_node = this;
-                const code = doc.createElement('code');
-                if (this.attributes.language) {
-                    code.setAttribute('class', `language-${this.attributes.language}`);
-                }
-                code.textContent = this.children.length > 0 ? this.children[0].content : this.content;
-                pre.appendChild(code);
-                return pre;
-            }
-
-            case 'list': {
-                const isOrdered = this.attributes.ordered;
-                const listEl = doc.createElement(isOrdered ? 'ol' : 'ul');
-                listEl.__st_node = this;
-                if (isOrdered && this.attributes.number > 1) {
-                    listEl.setAttribute('start', String(this.attributes.number));
-                }
-                for (const child of this.children) {
-                    listEl.appendChild(child.toDOM(doc));
-                }
-                return listEl;
-            }
-
-            case 'list-item': {
-                const li = doc.createElement('li');
-                li.__st_node = this;
-                if (typeof this.attributes.checked === 'boolean') {
-                    const checkbox = doc.createElement('input');
-                    checkbox.setAttribute('type', 'checkbox');
-                    if (this.attributes.checked) {
-                        checkbox.setAttribute('checked', '');
-                    }
-                    li.appendChild(checkbox);
-                    li.appendChild(doc.createTextNode(' '));
-                }
-                // Append inline children (text, bold, etc.) but not nested lists
-                const inlineChildren = this.children.filter((c) => c.type !== 'list');
-                SyntaxNode.appendInlineChildrenToDOM(doc, inlineChildren, li);
-                // Append nested list children
-                for (const child of this.children) {
-                    if (child.type === 'list') {
-                        li.appendChild(child.toDOM(doc));
-                    }
-                }
-                return li;
-            }
-
-            case 'horizontal-rule': {
-                const hr = doc.createElement('hr');
-                hr.__st_node = this;
-                return hr;
-            }
-
-            case 'image': {
-                const alt = this.attributes.alt ?? this.content ?? '';
-                const src = this.attributes.url ?? '';
-                const style = this.attributes.style ?? '';
-
-                const figure = doc.createElement('figure');
-                figure.__st_node = this;
-
-                if (alt) {
-                    const figcaption = doc.createElement('figcaption');
-                    figcaption.textContent = alt;
-                    figure.appendChild(figcaption);
-                }
-
-                const img = doc.createElement('img');
-                img.setAttribute('src', src);
-                img.setAttribute('alt', alt);
-                if (style) img.setAttribute('style', style);
-
-                if (this.attributes.href) {
-                    const a = doc.createElement('a');
-                    a.setAttribute('href', this.attributes.href);
-                    a.appendChild(img);
-                    figure.appendChild(a);
-                } else {
-                    figure.appendChild(img);
-                }
-
-                return figure;
-            }
-
-            case 'table': {
-                const table = doc.createElement('table');
-                table.__st_node = this;
-
-                const thead = doc.createElement('thead');
-                const tbody = doc.createElement('tbody');
-
-                for (const child of this.children) {
-                    const tr = doc.createElement('tr');
-                    const isHeader = child.type === 'header';
-                    for (const cell of child.children) {
-                        const el = doc.createElement(isHeader ? 'th' : 'td');
-                        const text = cell.children.length > 0 ? cell.children[0].content : '';
-                        el.appendChild(SyntaxNode.renderInlineContentToDOM(doc, text));
-                        tr.appendChild(el);
-                    }
-                    if (isHeader) {
-                        thead.appendChild(tr);
-                    } else {
-                        tbody.appendChild(tr);
-                    }
-                }
-
-                if (thead.childNodes.length > 0) {
-                    table.appendChild(thead);
-                }
-                if (tbody.childNodes.length > 0) {
-                    table.appendChild(tbody);
-                }
-
-                return table;
-            }
-
-            case 'html-block': {
-                const tagName = this.tagName || 'div';
-                const el = doc.createElement(tagName);
-                el.__st_node = this;
-
-                if (this.runtime.openingTag) {
-                    const temp = doc.createElement('div');
-                    temp.innerHTML = this.runtime.openingTag;
-                    const sourceEl = temp.firstElementChild;
-                    if (sourceEl) {
-                        for (const attr of sourceEl.attributes) {
-                            el.setAttribute(attr.name, attr.value);
-                        }
-                    }
-                }
-
-                if (
-                    this.children.length === 1 &&
-                    this.children[0].attributes.bareText &&
-                    this.children[0].type === 'paragraph'
-                ) {
-                    SyntaxNode.appendInlineChildrenToDOM(doc, this.children[0].children, el);
-                } else {
-                    renderBlockChildrenToDOM(doc, this.children, el);
-                }
-
-                return el;
-            }
-
-            default: {
-                const el = doc.createElement('div');
-                el.__st_node = this;
-                el.textContent = this.content;
-                return el;
-            }
-        }
-    }
-}
-
-// ── DOM rendering helpers ───────────────────────────────────────────
-
-/**
- * Renders an array of block-level SyntaxNode children into a DOM
- * container.
- * @param {Document} doc
- * @param {SyntaxNode[]} children
- * @param {Element} container
- */
-function renderBlockChildrenToDOM(doc, children, container) {
-    for (const child of children) {
-        container.appendChild(child.toDOM(doc));
+        return renderNodeToDOM(doc, this);
     }
 }
 
@@ -751,13 +168,7 @@ export class SyntaxTree {
      * @returns {string}
      */
     toMarkdown() {
-        const lines = [];
-
-        for (const child of this.children) {
-            lines.push(child.toMarkdown());
-        }
-
-        return lines.join('\n\n') + '\n';
+        return serializeTreeMarkdown(this);
     }
 
     /**
@@ -769,10 +180,7 @@ export class SyntaxTree {
      * @returns {Element}
      */
     toDOM(doc) {
-        const d = doc || this.doc;
-        const container = d.createElement('div');
-        renderBlockChildrenToDOM(d, this.children, container);
-        return container;
+        return renderTreeToDOM(doc || this.doc, this);
     }
 
     /**


### PR DESCRIPTION
- Extract toMarkdown serializer to render-tree-as-markdown.js
- Extract toDOM renderer to render-tree-as-dom.js
- Eliminate InlineSegment intermediate representation
- Move inline-tokenizer.js and parse-inline-content.js to parser package
- Remove parsing logic from SyntaxNode (parser owns all parsing)
- Remove parser dependency from DOM renderer
- Support arbitrary HTML elements in inline tokenizer
- Unify html-block/html-inline into single html-element type
- Add table spec test with inline formatting and nested HTML